### PR TITLE
Support ordering / filtering / querying by the order of the QuerySets in a QuerySetSequence.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@
 Changelog
 #########
 
+0.7 (xxxx-xx-xx)
+================
+
+* [Feature] Allow filtering / querying / ordering by the order of the
+  ``QuerySets`` in the ``QuerySetSequence`` by using ``'#'``. This allows for
+  additional optimizations when using third-party applications, e.g. Django REST
+  Framework.
+
 0.6.1 (2016-08-03)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -46,40 +46,41 @@ multiple ``QuerySets``:
       - Notes
     * - |filter|_
       - |check|
-      - 
+      - See [1]_ for information on the ``QuerySet`` lookup: ``'#'``.
     * - |exclude|_
       - |check|
-      - 
+      - See [1]_ for information on the ``QuerySet`` lookup: ``'#'``.
     * - |annotate|_
       - |xmark|
       - 
     * - |order_by|_
       - |check|
-      - Does not support random ``order_by()`` (e.g. ``order_by('?')``)
+      - Does not support random ordering (e.g. ``order_by('?')``). See [1]_ for
+        information on the ``QuerySet`` lookup: ``'#'``.
     * - |reverse|_
       - |check|
       - 
     * - |distinct|_
       - |xmark|
-      - 
+      -
     * - |values|_
       - |xmark|
-      - 
+      -
     * - |values_list|_
       - |xmark|
-      - 
+      -
     * - |dates|_
       - |xmark|
-      - 
+      -
     * - |datetimes|_
       - |xmark|
-      - 
+      -
     * - |none|_
       - |check|
-      - 
+      -
     * - |all|_
       - |check|
-      - 
+      -
     * - |select_related|_
       - |check|
       - 
@@ -106,7 +107,7 @@ multiple ``QuerySets``:
       - 
     * - |get|_
       - |check|
-      - 
+      - See [1]_ for information on the ``QuerySet`` lookup: ``'#'``.
     * - |create|_
       - |xmark|
       - Cannot be implemented in ``QuerySetSequence``.
@@ -230,8 +231,48 @@ multiple ``QuerySets``:
 .. _delete: https://docs.djangoproject.com/en/dev/ref/models/querysets/#delete
 .. |as_manager| replace:: ``as_manager()``
 .. _as_manager: https://docs.djangoproject.com/en/dev/ref/models/querysets/#as_manager
-.. ATTRIBUTES_TABLE_END
-.. End auto-generate content.
+
+
+.. [1]  ``QuerySetSequence`` supports a special field lookup that looks up the
+        index of the ``QuerySet``, this is represented by ``'#'``. This can be
+        used in any of the operations that normally take field lookups (i.e.
+        ``filter()``, ``exclude()``, and ``get()``), as well as ``order_by()``.
+
+        A few examples are below:
+
+        .. code-block:: python
+
+            # Order first by QuerySet, then by the value of the 'title' field.
+            QuerySetSequence(...).order_by('#', 'title')
+
+            # Filter out the first QuerySet.
+            QuerySetSequence(...).filter(**{'#__gt': 0})
+
+        .. note::
+
+            Ordering first by ``QuerySet`` allows for a more optimized code path
+            when iterating over the entries.
+
+        .. warning::
+
+            Not all lookups are supported when using ``'#'`` (some lookups
+            simply don't make sense; others are just not supported). The
+            following are allowed:
+
+            * ``exact``
+            * ``iexact``
+            * ``contains``
+            * ``icontains``
+            * ``in``
+            * ``gt``
+            * ``gte``
+            * ``lt``
+            * ``lte``
+            * ``startswith``
+            * ``istartswith``
+            * ``endswith``
+            * ``iendswith``
+            * ``range``
 
 Requirements
 ============

--- a/queryset_sequence.py
+++ b/queryset_sequence.py
@@ -537,7 +537,7 @@ class QuerySetSequence(six.with_metaclass(PartialInheritanceMeta, QuerySet)):
 
         """
         # Start with all QuerySets.
-        querysets = range(len(self.query._querysets))
+        querysets = list(range(len(self.query._querysets)))
 
         # Ensure negate is a boolean.
         negate = bool(negate)
@@ -580,19 +580,19 @@ class QuerySetSequence(six.with_metaclass(PartialInheritanceMeta, QuerySet)):
 
             # Some of these seem to get handled as bytes.
             if lookup in ('contains', 'icontains'):
-                value = bytes(value)
-                querysets = filter(lambda i:(value in bytes(i)) != negate, querysets)
+                value = six.text_type(value)
+                querysets = filter(lambda i: (value in six.text_type(i)) != negate, querysets)
 
             elif lookup == 'in':
                 querysets = filter(lambda i: (i in value) != negate, querysets)
 
             elif lookup in ('startswith', 'istartswith'):
-                value = bytes(value)
-                querysets = filter(lambda i: bytes(i).startswith(value) != negate, querysets)
+                value = six.text_type(value)
+                querysets = filter(lambda i: six.text_type(i).startswith(value) != negate, querysets)
 
             elif lookup in ('endswith', 'iendswith'):
-                value = bytes(value)
-                querysets = filter(lambda i: bytes(i).endswith(value) != negate, querysets)
+                value = six.text_type(value)
+                querysets = filter(lambda i: six.text_type(i).endswith(value) != negate, querysets)
 
             elif lookup == 'range':
                 # Inclusive include.
@@ -604,6 +604,9 @@ class QuerySetSequence(six.with_metaclass(PartialInheritanceMeta, QuerySet)):
                 # day, week_day, hour, minute, second, isnull, search, regex, and
                 # iregex.
                 raise ValueError("Unsupported lookup '%s'" % lookup)
+
+            # Keep querysets a list in Python 3.
+            querysets = list(querysets)
 
         # Finally, trim down the actual QuerySets we care about!
         self.query._querysets = [self.query._querysets[i] for i in querysets]

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -348,6 +348,20 @@ class TestFilter(TestBase):
         data = list(qss)
         self.assertEqual(len(data), 0)
 
+    def test_queryset(self):
+        """Ensure we can order by QuerySet and then other fields."""
+        qss = self.all.filter(**{'#': 1})
+
+        # Only the articles are here because it's the second queryset.
+        data = [it.title for it in qss]
+        expected = [
+            # Then the Articles.
+            'Django Rocks',
+            'Alice in Django-land',
+            'Some Article',
+        ]
+        self.assertEqual(data, expected)
+
 
 class TestExclude(TestBase):
     """


### PR DESCRIPTION
This adds `'#'` as a field lookup that supports a few things:
* Can be used in `order_by()` to first order by `QuerySet`, then follow the other field orderings. (This is useful to get a more optimal code path when iterating over the values in a `QuerySetSequence`.)
* Can be used in `filter()` / `exclude()` / `get()` to limit the `QuerySets` in use (by their order). This can be combined with normal [field lookups](https://docs.djangoproject.com/en/1.9/ref/models/querysets/#field-lookups), e.g. `#__gt` to do `QuerySets` greater than some number.

Includes tests and documentation.