### PR TITLE
Add additional tests for PartialInheritanceMeta.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Changelog
   Framework.
 * [Enhancement] Move ``queryset_sequence`` to an actual module in order to hide
   some implementation details.
+* [Bugfix] ``PartialInheritanceMeta`` must be provided ``INHERITED_ATTRS`` and
+  ``NOT_IMPLEMENTED_ATTRS``.
 
 0.6.1 (2016-08-03)
 ==================

--- a/queryset_sequence/_inheritance.py
+++ b/queryset_sequence/_inheritance.py
@@ -1,5 +1,10 @@
 import functools
 
+
+class PartialInheritanceError(Exception):
+    """An object is incorrectly configured when using PartialInheritanceMeta."""
+
+
 class PartialInheritanceMeta(type):
     """
     A metaclass which allows partial inheritance of attributes from a
@@ -24,7 +29,8 @@ class PartialInheritanceMeta(type):
             INHERITED_ATTRS = dct['INHERITED_ATTRS']
             del dct['INHERITED_ATTRS']
         except KeyError:
-            INHERITED_ATTRS = []
+            raise PartialInheritanceError(
+                "Class '%s' must provide 'INHERITED_ATTRS'." % name)
 
         try:
             NOT_IMPLEMENTED_ATTRS = dct['NOT_IMPLEMENTED_ATTRS']
@@ -39,7 +45,8 @@ class PartialInheritanceMeta(type):
             for attr in NOT_IMPLEMENTED_ATTRS:
                 dct[attr] = functools.partial(not_impl, attr)
         except KeyError:
-            NOT_IMPLEMENTED_ATTRS = []
+            raise PartialInheritanceError(
+                "Class '%s' must provide 'NOT_IMPLEMENTED_ATTRS'." % name)
 
         # Create the actual class.
         cls = type.__new__(meta, name, bases, dct)

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -35,6 +35,10 @@ class B(six.with_metaclass(PartialInheritanceMeta, A)):
         return -result
 
 
+class C(six.with_metaclass(PartialInheritanceMeta, A)):
+    """A class that doesn't define INHERITED_ATTRS or NOT_IMPLEMENTED_ATTRS."""
+
+
 class TestPartialInheritanceMeta(TestCase):
     def assertExceptionMessageEquals(self, exception, expected):
         result = exception.message if six.PY2 else exception.args[0]
@@ -123,3 +127,20 @@ class TestPartialInheritanceMeta(TestCase):
 
         self.assertTrue(hasattr(self.b, 'e'))
         self.assertEqual(self.b.e(), -17)
+
+    def test_undefined(self):
+        """
+        Test for when a sub-class doesn't define INHERITED_ATTRS or NOT_IMPLEMENTED_ATTRS.
+
+        Note this is the same as empty lists, so nothing is inherited and nothing raises NotImplemented.
+        """
+        c = C()
+        self.assertFalse(hasattr(c, 'a'))
+        self.assertFalse(hasattr(c, 'b'))
+        self.assertFalse(hasattr(c, 'c'))
+        self.assertFalse(hasattr(c, 'd'))
+        self.assertFalse(hasattr(c, 'e'))
+
+        # This property is dynamically created.
+        self.assertTrue(hasattr(c, 'z'))
+        self.assertEqual(c.z, 42)


### PR DESCRIPTION
Not providing `INHERITED_ATTRS` or `NOT_IMPLEMENTED_ATTRS` treats them as empty.