### PR TITLE
Minor fixes to QuerySet number (#10)

### DIFF
--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -73,6 +73,9 @@ class QuerySequence(six.with_metaclass(PartialInheritanceMeta, Query)):
 
     def __init__(self, *args):
         self._querysets = list(args)
+        # Mark each QuerySet's Model with the number of the QuerySet it is.
+        for i, qs in enumerate(self._querysets):
+            setattr(qs.model, '#', i)
 
         # Call super to pick up a variety of properties.
         super(QuerySequence, self).__init__(model=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 # Not tested with older versions of Django.
 Django>=1.8.0
+mock

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -472,7 +472,6 @@ class TestFilter(TestBase):
             ]
             self.assertEqual(data, expected)
 
-
     def test_queryset_range(self):
         """Try filtering the QuerySets by the range lookup."""
         qss = self._get_qss().filter(**{'#__range': [1, 2]})
@@ -492,6 +491,29 @@ class TestFilter(TestBase):
         """Try filtering the QuerySets by a lookup that doesn't make sense."""
         with self.assertRaises(ValueError):
             self._get_qss().filter(**{'#__year': 1})
+
+    def test_queryset_multiple(self):
+        """
+        When using multiple paramters to filter they get ANDed together. Ensure
+        this works when filtering by QuerySet.
+        """
+        qss = self._get_qss().filter(**{'#__gt': 0, 'title__gt': 'Django Rocks'})
+
+        data = [it.title for it in qss]
+        expected = [
+            # Some of the Articles and the BlogPosts.
+            'Some Article',
+            'Post',
+        ]
+        self.assertEqual(data, expected)
+
+        # This would only look at Articles and BlogPosts, but neither of those
+        # have a title > "Some Article."
+        qss = self._get_qss().filter(**{'#__gt': 0, 'title__gt': 'Some Article'})
+
+        # Only the articles are here because it's the second queryset.
+        data = [it.title for it in qss]
+        self.assertEqual(data, [])
 
 
 class TestExclude(TestBase):

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -3,7 +3,10 @@ from django.core.exceptions import (FieldError, MultipleObjectsReturned,
 from django.db.models.query import EmptyQuerySet, QuerySet
 from django.test import TestCase
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from queryset_sequence import QuerySetSequence
 
@@ -116,12 +119,12 @@ class TestQuerySetSequence(TestBase):
 
 class TestQuerySequence(TestBase):
     def test_queryset_number(self):
-        data = map(lambda d: getattr(d, '#'), self.all._clone())
+        data = list(map(lambda d: getattr(d, '#'), self.all._clone()))
         self.assertEqual([0, 0, 1, 1, 1], data)
 
     def test_queryset_number_(self):
         """The number shouldn't change during filter, etc."""
-        data = map(lambda d: getattr(d, '#'), self.all.filter(**{'#': 1}))
+        data = list(map(lambda d: getattr(d, '#'), self.all.filter(**{'#': 1})))
         self.assertEqual([1, 1, 1], data)
 
 

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -112,6 +112,17 @@ class TestQuerySetSequence(TestBase):
         self.assertEqual(data, self.EXPECTED_WITH_BOOK_MODEL)
 
 
+class TestQuerySequence(TestBase):
+    def test_queryset_number(self):
+        data = map(lambda d: getattr(d, '#'), self.all._clone())
+        self.assertEqual([0, 0, 1, 1, 1], data)
+
+    def test_queryset_number_(self):
+        """The number shouldn't change during filter, etc."""
+        data = map(lambda d: getattr(d, '#'), self.all.filter(**{'#': 1}))
+        self.assertEqual([1, 1, 1], data)
+
+
 class TestLength(TestBase):
     """
     Ensure that count() and len() are properly summed over the children

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     python run_coveralls.py
 deps =
     coveralls
-    mock
+    py27: mock
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands =
     python run_coveralls.py
 deps =
     coveralls
+    mock
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11


### PR DESCRIPTION
#10 had a few minor issues with it. This also adds the `QuerySet` number to each returned item as an attribute.