### PR TITLE
Treat QuerySet lookups as numbers.

### DIFF
--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -524,6 +524,13 @@ class QuerySetSequence(six.with_metaclass(PartialInheritanceMeta, QuerySet)):
             }
             try:
                 operator = LOOKUP_TO_OPERATOR[lookup]
+
+                # These expect integers, this matches the logic in
+                # IntegerField.get_prep_value(). (Essentially treat the '#'
+                # field as an IntegerField.)
+                if value is not None:
+                    value = int(value)
+
                 querysets = filter(lambda i: operator(i, value) != negate, querysets)
                 continue
             except KeyError:

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -401,6 +401,20 @@ class TestFilter(TestBase):
         ]
         self.assertEqual(data, expected)
 
+        # Additionally this should cast a string input to an int.
+        qss = self._get_qss().filter(**{'#__gt': '0'})
+
+        # Only the articles are here because it's the second queryset.
+        data = [it.title for it in qss]
+        expected = [
+            # The Articles and BlogPosts.
+            'Django Rocks',
+            'Alice in Django-land',
+            'Some Article',
+            'Post',
+        ]
+        self.assertEqual(data, expected)
+
     def test_queryset_gte(self):
         """Test filtering the QuerySets by >= lookup."""
         qss = self._get_qss().filter(**{'#__gte': 1})

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -376,7 +376,6 @@ class TestFilter(TestBase):
         for key in ['#', '#__exact', '#__iexact']:
             qss = self._get_qss().filter(**{key: 1})
 
-            # Only the articles are here because it's the second queryset.
             data = [it.title for it in qss]
             expected = [
                 # Just the Articles.
@@ -390,7 +389,6 @@ class TestFilter(TestBase):
         """Test filtering the QuerySets by > lookup."""
         qss = self._get_qss().filter(**{'#__gt': 0})
 
-        # Only the articles are here because it's the second queryset.
         data = [it.title for it in qss]
         expected = [
             # The Articles and BlogPosts.
@@ -404,7 +402,6 @@ class TestFilter(TestBase):
         # Additionally this should cast a string input to an int.
         qss = self._get_qss().filter(**{'#__gt': '0'})
 
-        # Only the articles are here because it's the second queryset.
         data = [it.title for it in qss]
         expected = [
             # The Articles and BlogPosts.
@@ -419,7 +416,6 @@ class TestFilter(TestBase):
         """Test filtering the QuerySets by >= lookup."""
         qss = self._get_qss().filter(**{'#__gte': 1})
 
-        # Only the articles are here because it's the second queryset.
         data = [it.title for it in qss]
         expected = [
             # The Articles and BlogPosts.
@@ -434,7 +430,6 @@ class TestFilter(TestBase):
         """Test filtering the QuerySets by < lookup."""
         qss = self._get_qss().filter(**{'#__lt': 2})
 
-        # Only the articles are here because it's the second queryset.
         data = [it.title for it in qss]
         expected = [
             # The Books and Articles.
@@ -450,7 +445,6 @@ class TestFilter(TestBase):
         """Test filtering the QuerySets by <= lookup."""
         qss = self._get_qss().filter(**{'#__lte': 1})
 
-        # Only the articles are here because it's the second queryset.
         data = [it.title for it in qss]
         expected = [
             # The Books and Articles.
@@ -466,7 +460,6 @@ class TestFilter(TestBase):
         """Filter the QuerySets with the in lookup."""
         qss = self._get_qss().filter(**{'#__in': [1]})
 
-        # Only the articles are here because it's the second queryset.
         data = [it.title for it in qss]
         expected = [
             # The Articles.
@@ -481,7 +474,6 @@ class TestFilter(TestBase):
         for key in ['#__contains', '#__icontains', '#__startswith', '#__istartswith', '#__endswith', '#__iendswith']:
             qss = self._get_qss().filter(**{key: 1})
 
-            # Only the articles are here because it's the second queryset.
             data = [it.title for it in qss]
             expected = [
                 # Just the Articles.
@@ -495,7 +487,6 @@ class TestFilter(TestBase):
         """Try filtering the QuerySets by the range lookup."""
         qss = self._get_qss().filter(**{'#__range': [1, 2]})
 
-        # Only the articles are here because it's the second queryset.
         data = [it.title for it in qss]
         expected = [
             # Just the Articles.


### PR DESCRIPTION
When doing things like `gt` or `exact` lookups on an `IntegerField`, Django [casts the supplied value to an `int`](https://github.com/django/django/blob/3c447b108ac70757001171f7a4791f493880bf5b/django/db/models/fields/__init__.py#L1832-L1836) before using it. We should be doing the same here.