### PR TITLE
Add an efficient Django REST Framework paginator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -364,6 +364,30 @@ Example
     published_works = published_works.order_by('title')
     print([w.title for w in published_works])  # prints ['Biography', 'Dancing with Django', 'Django-isms']
 
+Django REST Framework integration
+=================================
+
+django-querysetsequence comes with a custom ``CursorPagination`` class that
+helps integration with Django REST Framework. It is optimized to iterate over a
+``QuerySetSequence`` first by ``QuerySet`` and then by the normal ``ordering``
+configuration. This uses the optimized code-path for iteration that avoids
+interleaving the individual ``QuerySets``. For example:
+
+.. code-block:: python
+
+    from queryset_sequence.pagination import SequenceCursorPagination
+
+    class PublicationPagination(SequenceCursorPagination):
+        ordering = ['author', 'title']
+
+    class PublicationViewSet(viewsets.ModelViewSet):
+        pagination_class = PublicationPagination
+
+        def get_queryset(self):
+            # This will return all Books first, then all Articles. Each of those
+            # is individually ordered by ``author``, then ``title``.
+            return QuerySetSequence(Book.objects.all(), Article.objects.all())
+
 Attribution
 ===========
 

--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,28 @@ Requirements
 
 * Python (2.7, 3.4, 3.5)
 * Django (1.8, 1.9, 1.10)
+* (Optionally) Django REST Framework (3.2, 3.3, 3.4)
+
+.. list-table:: ``QuerySetSequence`` versions with support for Django/Django REST Framework
+    :header-rows: 1
+    :stub-columns: 1
+
+    * -
+      - Django 1.8
+      - Django 1.9
+      - Django 1.10
+    * - Django REST Framework 3.2
+      - 0.7
+      - |xmark|
+      - |xmark|
+    * - Django REST Framework 3.3
+      - 0.7
+      - 0.7
+      - |xmark|
+    * - Django REST Framework 3.4
+      - 0.7
+      - 0.7
+      - 0.7
 
 Installation
 ============

--- a/queryset_sequence/pagination.py
+++ b/queryset_sequence/pagination.py
@@ -1,0 +1,211 @@
+"""
+More efficient pagination for django-querysetsequence when using Django REST
+Framework.
+
+The standard Django REST Framework pagination classes will work fine. The
+classes provided here are useful when providing large datasets that use
+QuerySetSequence over an API as they first order by the QuerySet number and then
+particular fields.
+
+"""
+from base64 import b64decode
+
+from django.utils.six.moves.urllib import parse as urlparse
+
+from queryset_sequence import QuerySetSequence
+
+try:
+    from rest_framework.exceptions import NotFound
+    from rest_framework.pagination import (_positive_int,
+                                           _reverse_ordering,
+                                           Cursor,
+                                           CursorPagination)
+except ImportError:
+    # This requires Django REST Framework to be installed.
+    raise ImportError(
+        "queryset_sequence.pagination is for use with Django REST Framework, "
+        "which was not found.")
+
+
+class SequenceCursorPagination(CursorPagination):
+    """
+    Heavily customized CursorPagination to first sort by QuerySet, then by a
+    different ordering field.
+
+    Changes include:
+    * Don't override self.ordering with the output of get_ordering()
+    * The filtering logic is significantly changed to deal with a tuple of fields.
+
+    """
+
+    def paginate_queryset(self, queryset, request, view=None):
+        # This code only works with a QuerySetSequence.
+        if not isinstance(queryset, QuerySetSequence):
+            raise ValueError(
+                "%s can only be used with an instance of QuerySetSequence." %
+                self.__class__.__name__)
+
+        self.page_size = self.get_page_size(request)
+        if not self.page_size:
+            return None
+
+        self.base_url = request.build_absolute_uri()
+        self.ordering = self.get_ordering(request, queryset, view)
+
+        self.cursor = self.decode_cursor(request)
+        if self.cursor is None:
+            (offset, reverse, current_position) = (0, False, None)
+        else:
+            (offset, reverse, current_position) = self.cursor
+
+        # Cursor pagination always enforces an ordering.
+        if reverse:
+            queryset = queryset.order_by(*_reverse_ordering(self.ordering))
+        else:
+            queryset = queryset.order_by(*self.ordering)
+
+        # If we have a cursor with a fixed position then filter by that.
+        if current_position is not None:
+            # Iterate over each positioning.
+            for order, position in zip(self.ordering[:len(current_position)], current_position):
+                # The inside of this loop is essentially the old logic.
+                is_reversed = order.startswith('-')
+                order_attr = order.lstrip('-')
+
+                # The filtering code in paginate_queryset uses ge or le, so
+                # offset these based on that.
+                if order_attr == '#':
+                    equal = 'e'
+                else:
+                    equal = ''
+
+                # Test for: (cursor reversed) XOR (queryset reversed)
+                if self.cursor.reverse != is_reversed:
+                    kwargs = {order_attr + '__lt' + equal: position}
+                else:
+                    kwargs = {order_attr + '__gt' + equal: position}
+
+                # If filtering on the number of the QuerySet, apply it to the
+                # entire QuerySetSequence.
+                if order_attr == '#':
+                    queryset = queryset.filter(**kwargs)
+
+                # If there *are* QuerySets, filter just the edge QuerySet. This
+                # avoids trimming items in subsequent QuerySets that are still
+                # valid.
+                elif queryset.query._querysets:
+                    queryset = queryset._clone()
+
+                    # Make a copy of the current QuerySets.
+                    querysets = queryset.query._querysets
+                    # Handle whether to look at the front edge or back edge of
+                    # the QuerySets based on the order of iteration.
+                    if self.cursor.reverse != is_reversed:
+                        queryset.query._querysets = (
+                            querysets[:-1] +
+                            [querysets[-1].filter(**kwargs)])
+                    else:
+                        queryset.query._querysets = (
+                            [querysets[0].filter(**kwargs)] +
+                            querysets[1:])
+
+        # If we have an offset cursor then offset the entire page by that amount.
+        # We also always fetch an extra item in order to determine if there is a
+        # page following on from this one.
+        results = list(queryset[offset:offset + self.page_size + 1])
+        self.page = list(results[:self.page_size])
+
+        # Determine the position of the final item following the page.
+        if len(results) > len(self.page):
+            has_following_position = True
+            following_position = self._get_position_from_instance(results[-1], self.ordering)
+        else:
+            has_following_position = False
+            following_position = None
+
+        # If we have a reverse queryset, then the query ordering was in reverse
+        # so we need to reverse the items again before returning them to the user.
+        if reverse:
+            self.page = list(reversed(self.page))
+
+        if reverse:
+            # Determine next and previous positions for reverse cursors.
+            self.has_next = (current_position is not None) or (offset > 0)
+            self.has_previous = has_following_position
+            if self.has_next:
+                self.next_position = current_position
+            if self.has_previous:
+                self.previous_position = following_position
+        else:
+            # Determine next and previous positions for forward cursors.
+            self.has_next = has_following_position
+            self.has_previous = (current_position is not None) or (offset > 0)
+            if self.has_next:
+                self.next_position = following_position
+            if self.has_previous:
+                self.previous_position = current_position
+
+        # Display page controls in the browsable API if there is more
+        # than one page.
+        if (self.has_previous or self.has_next) and self.template is not None:
+            self.display_page_controls = True
+
+        return self.page
+
+    def get_ordering(self, *args, **kwargs):
+        """Take whatever the expected ordering is and then first order by QuerySet."""
+        result = super(SequenceCursorPagination, self).get_ordering(*args, **kwargs)
+
+        # Because paginate_queryset sets self.ordering after reading it...we
+        # need to only modify it sometimes. (This allows re-use of the
+        # paginator, which probably only happens in tests.)
+        if result[0] != '#':
+            result = ('#', ) + result
+
+        return result
+
+    def _get_position_from_instance(self, instance, ordering):
+        """
+        The position will be a tuple of values:
+
+            The QuerySet number inside of the QuerySetSequence.
+            Whatever the normal value taken from the ordering property gives.
+
+        """
+        # Get the QuerySet number of the current instance.
+        qs_order = getattr(instance, '#')
+
+        # Strip the '#' and call the standard _get_position_from_instance.
+        result = super(SequenceCursorPagination, self)._get_position_from_instance(instance, ordering[1:])
+
+        # Return a tuple of these two elements.
+        return (qs_order, result)
+
+    def decode_cursor(self, request):
+        """
+        Given a request with a cursor, return a `Cursor` instance.
+
+        Differs from the standard CursorPagination to handle a tuple in the
+        position field.
+        """
+        # Determine if we have a cursor, and if so then decode it.
+        encoded = request.query_params.get(self.cursor_query_param)
+        if encoded is None:
+            return None
+
+        try:
+            querystring = b64decode(encoded.encode('ascii')).decode('ascii')
+            tokens = urlparse.parse_qs(querystring, keep_blank_values=True)
+
+            offset = tokens.get('o', ['0'])[0]
+            offset = _positive_int(offset, cutoff=self.offset_cutoff)
+
+            reverse = tokens.get('r', ['0'])[0]
+            reverse = bool(int(reverse))
+
+            # The difference. Don't get just the 0th entry: get all entries.
+            position = tokens.get('p', [None])
+        except (TypeError, ValueError):
+            raise NotFound(self.invalid_cursor_message)
+
+        return Cursor(offset=offset, reverse=reverse, position=position)

--- a/queryset_sequence/pagination.py
+++ b/queryset_sequence/pagination.py
@@ -209,7 +209,7 @@ class SequenceCursorPagination(CursorPagination):
             reverse = bool(int(reverse))
 
             # The difference. Don't get just the 0th entry: get all entries.
-            position = tokens.get('p', [None])
+            position = tokens.get('p', None)
         except (TypeError, ValueError):
             raise NotFound(self.invalid_cursor_message)
 

--- a/queryset_sequence/pagination.py
+++ b/queryset_sequence/pagination.py
@@ -198,7 +198,12 @@ class SequenceCursorPagination(CursorPagination):
             tokens = urlparse.parse_qs(querystring, keep_blank_values=True)
 
             offset = tokens.get('o', ['0'])[0]
-            offset = _positive_int(offset, cutoff=self.offset_cutoff)
+            # This was hard-coded until Django REST Framework 3.4.0.
+            try:
+                offset_cutoff = self.offset_cutoff
+            except AttributeError:
+                offset_cutoff = 1000
+            offset = _positive_int(offset, cutoff=offset_cutoff)
 
             reverse = tokens.get('r', ['0'])[0]
             reverse = bool(int(reverse))

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -13,6 +13,7 @@ try:
     from queryset_sequence.pagination import SequenceCursorPagination
 except ImportError:
     factory = None
+    SequenceCursorPagination = object
 
 from queryset_sequence import QuerySetSequence
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,131 @@
+import unittest
+
+from django.test import TestCase
+
+# In-case someone doesn't have Django REST Framework installed, guard tests.
+try:
+    from rest_framework import exceptions, filters
+    from rest_framework.request import Request
+    from rest_framework.test import APIRequestFactory
+
+    factory = APIRequestFactory()
+
+    from queryset_sequence.pagination import SequenceCursorPagination
+except ImportError:
+    factory = None
+
+from queryset_sequence import QuerySetSequence
+
+from tests.models import Author, Book, Publisher
+
+
+@unittest.skipIf(not factory, 'Must have Django REST Framework installed to run pagination tests.')
+class TestSequenceCursorPagination(TestCase):
+    """
+    Unit tests for `queryset_sequence.pagination.SequenceCursorPagination`.
+
+    Heavily based on `tests.test_pagination` from Django REST Framework.
+    """
+
+    PAGE_1 = [1, 2, 3, 4, 5]
+    PAGE_2 = [6, 7, 8, 9, 10]
+    PAGE_3 = [11, 12, 13, 14]
+
+    def setUp(self):
+        class ExamplePagination(SequenceCursorPagination):
+            page_size = 5
+            # The test models don't have a 'created' field.
+            ordering = 'pages'
+
+        author = Author.objects.create(name="Jane Doe")
+        publisher = Publisher.objects.create(name="Pablo's Publishing",
+                                             address="123 Publishing Street")
+
+        for d in xrange(1, 15):
+            book = Book.objects.create(title='Book %s' % d,
+                                       author=author,
+                                       publisher=publisher,
+                                       pages=d)
+
+        self.pagination = ExamplePagination()
+        self.queryset = QuerySetSequence(Book.objects.filter(pages__lte=7),
+                                         Book.objects.filter(pages__gt=7))
+
+    def get_pages(self, url):
+        """
+        Given a URL return a tuple of:
+        (previous page, current page, next page, previous url, next url)
+        """
+        request = Request(factory.get(url))
+        queryset = self.pagination.paginate_queryset(self.queryset, request)
+        current = [item.pages for item in queryset]
+
+        next_url = self.pagination.get_next_link()
+        previous_url = self.pagination.get_previous_link()
+
+        if next_url is not None:
+            request = Request(factory.get(next_url))
+            queryset = self.pagination.paginate_queryset(self.queryset, request)
+            next = [item.pages for item in queryset]
+        else:
+            next = None
+
+        if previous_url is not None:
+            request = Request(factory.get(previous_url))
+            queryset = self.pagination.paginate_queryset(self.queryset, request)
+            previous = [item.pages for item in queryset]
+        else:
+            previous = None
+
+        return (previous, current, next, previous_url, next_url)
+
+    def test_ordering(self):
+        """Ensure that the QuerySetSequence is ordered as expected."""
+        pages = [b.pages for b in self.queryset]
+        self.assertEqual(pages, self.PAGE_1 + self.PAGE_2 + self.PAGE_3)
+
+        # The first 7 are in the 0th list, the last 7 are in the 1st list.
+        number = [getattr(b, '#') for b in self.queryset]
+        self.assertEqual(number, [0] * 7 + [1] * 7)
+
+    def test_invalid_cursor(self):
+        request = Request(factory.get('/', {'cursor': '123'}))
+        with self.assertRaises(exceptions.NotFound):
+            self.pagination.paginate_queryset(self.queryset, request)
+
+    def test_use_with_ordering_filter(self):
+        class MockView:
+            filter_backends = (filters.OrderingFilter,)
+            ordering_fields = ['title', 'author']
+            ordering = 'title'
+
+        request = Request(factory.get('/', {'ordering': 'author'}))
+        ordering = self.pagination.get_ordering(request, [], MockView())
+        self.assertEqual(ordering, ('#', 'author',))
+
+        request = Request(factory.get('/', {'ordering': '-author'}))
+        ordering = self.pagination.get_ordering(request, [], MockView())
+        self.assertEqual(ordering, ('#', '-author',))
+
+        request = Request(factory.get('/', {'ordering': 'invalid'}))
+        ordering = self.pagination.get_ordering(request, [], MockView())
+        self.assertEqual(ordering, ('#', 'title',))
+
+    def test_cursor_pagination(self):
+        (previous, current, next, previous_url, next_url) = self.get_pages('/')
+
+        self.assertIsNone(previous)
+        self.assertEqual(current, self.PAGE_1)
+        self.assertEqual(next, self.PAGE_2)
+
+        (previous, current, next, previous_url, next_url) = self.get_pages(next_url)
+
+        self.assertEqual(previous, self.PAGE_1)
+        self.assertEqual(current, self.PAGE_2)
+        self.assertEqual(next, self.PAGE_3)
+
+        (previous, current, next, previous_url, next_url) = self.get_pages(next_url)
+
+        self.assertEqual(previous, self.PAGE_2)
+        self.assertEqual(current, self.PAGE_3)
+        self.assertIsNone(next)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -41,7 +41,7 @@ class TestSequenceCursorPagination(TestCase):
         publisher = Publisher.objects.create(name="Pablo's Publishing",
                                              address="123 Publishing Street")
 
-        for d in xrange(1, 15):
+        for d in range(1, 15):
             book = Book.objects.create(title='Book %s' % d,
                                        author=author,
                                        publisher=publisher,

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -19,6 +19,13 @@ from queryset_sequence import QuerySetSequence
 from tests.models import Author, Book, Publisher
 
 
+class _TestPagination(SequenceCursorPagination):
+    """A SequenceCursorPagination with a small page_size."""
+    page_size = 5
+    # The test models don't have a 'created' field.
+    ordering = 'pages'
+
+
 @unittest.skipIf(not factory, 'Must have Django REST Framework installed to run pagination tests.')
 class TestSequenceCursorPagination(TestCase):
     """
@@ -32,22 +39,17 @@ class TestSequenceCursorPagination(TestCase):
     PAGE_3 = [11, 12, 13, 14]
 
     def setUp(self):
-        class ExamplePagination(SequenceCursorPagination):
-            page_size = 5
-            # The test models don't have a 'created' field.
-            ordering = 'pages'
-
         author = Author.objects.create(name="Jane Doe")
         publisher = Publisher.objects.create(name="Pablo's Publishing",
                                              address="123 Publishing Street")
 
         for d in range(1, 15):
-            book = Book.objects.create(title='Book %s' % d,
+            book = Book.objects.create(title='Book %s' % (d % 2),
                                        author=author,
                                        publisher=publisher,
                                        pages=d)
 
-        self.pagination = ExamplePagination()
+        self.pagination = _TestPagination()
         self.queryset = QuerySetSequence(Book.objects.filter(pages__lte=7),
                                          Book.objects.filter(pages__gt=7))
 
@@ -129,3 +131,86 @@ class TestSequenceCursorPagination(TestCase):
         self.assertEqual(previous, self.PAGE_2)
         self.assertEqual(current, self.PAGE_3)
         self.assertIsNone(next)
+
+    def test_cursor_stableness(self):
+        """
+        Test what happens if we remove domains after loading a page.
+        Pages should be independent, i.e. a cursor points to a particular
+        domain, and shouldn't affect offsets.
+        """
+        (previous, current, next, previous_url, next_url) = self.get_pages('/')
+
+        # The first page is as normal.
+        self.assertIsNone(previous)
+        self.assertEqual(current, self.PAGE_1)
+        self.assertEqual(next, self.PAGE_2)
+
+        # Delete Books, this shouldn't affect the next request.
+        Book.objects.filter(pages__lte=3).delete()
+        Book.objects.filter(pages__gte=13).delete()
+
+        (previous, current, next, _, old_next_url) = self.get_pages(next_url)
+
+        # Should be some missing items
+        self.assertEqual(previous, [4, 5])
+        self.assertEqual(current, self.PAGE_2)
+        self.assertEqual(next, [11, 12])
+
+        # Deleting some from the current page and reloading should have the page
+        # offset.
+        Book.objects.get(pages=7).delete()
+
+        (previous, current, next, _, new_next_url) = self.get_pages(next_url)
+
+        # Should be some missing items
+        self.assertEqual(previous, [4, 5])
+        self.assertEqual(current, [6, 8, 9, 10, 11])
+        self.assertEqual(next, [12])
+
+        # The next_url returned with the different items missing will actually
+        # be different.
+        self.assertNotEqual(old_next_url, new_next_url)
+
+    def test_multiple_ordering(self):
+        """Test a Pagination with multiple items in the ordering attribute."""
+
+        # This will order by:
+        #   1. Even pages
+        #   2. Odd pages
+        #   3. Both of the above will be done in increasing order.
+        #   4. Ordering happens for 1 - 7, then 8 - 14.
+        class TestPagination(_TestPagination):
+            ordering = ['title', 'pages']
+
+        self.pagination = TestPagination()
+
+        PAGE_1 = [2, 4, 6, 1, 3]
+        PAGE_2 = [5, 7, 8, 10, 12]
+        PAGE_3 = [14, 9, 11, 13]
+
+        # Check that the ordering is as expected.
+        pages = [b.pages for b in self.queryset.order_by('#', *self.pagination.ordering)]
+        self.assertEqual(pages, PAGE_1 + PAGE_2 + PAGE_3)
+
+        # Now perform pretty much the same test as test_cursor_pagination, but
+        # the ordering will be different.
+        (previous, current, next, previous_url, next_url) = self.get_pages('/')
+
+        self.assertIsNone(previous)
+        self.assertEqual(current, PAGE_1)
+        self.assertEqual(next, PAGE_2)
+
+        (previous, current, next, previous_url, next_url) = self.get_pages(next_url)
+
+        self.assertEqual(previous, PAGE_1)
+        self.assertEqual(current, PAGE_2)
+        self.assertEqual(next, PAGE_3)
+
+        (previous, current, next, previous_url, next_url) = self.get_pages(next_url)
+
+        self.assertEqual(previous, PAGE_2)
+        self.assertEqual(current, PAGE_3)
+        self.assertIsNone(next)
+
+    def test_duplicates(self):
+        """Ensure that pagination works over an 'extreme' number of duplicates."""

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py27,py34,py35}-django{18,19,110,111}
+# Two sets of environments: combinations of Python versions with Django
+# versions, then combinations of Python versions with Django REST Framework
+# versions.
+envlist =
+    {py27,py34,py35}-django{18,19,110,master},
+    # Django REST Framework 3.2 added support for Django 1.8.
+    {py27,py34,py35}-django18-drf32,
+    # Django REST Framework 3.3, 3.4, and master support Django 1.8 and 1.9.
+    {py27,py34,py35}-django{18,19}-drf{33,34,master},
+    # Django REST Framework 3.4 added support for Django 1.10.
+    {py27,py34,py35}-django{110,master}-drf{34,master}
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -17,4 +27,8 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
-    django111: https://codeload.github.com/django/django/zip/master
+    djangomaster: https://codeload.github.com/django/django/zip/master
+    drf32: djangorestframework>=3.2,<3.3
+    drf33: djangorestframework>=3.3,<3.4
+    drf34: djangorestframework>=3.4,<3.5
+    drfmaster: https://codeload.github.com/tomchristie/django-rest-framework/zip/master


### PR DESCRIPTION
`QuerySetSequence` works well by feeding it into a Django REST Framework view, but it fails under large `QuerySets` due to sorting concerns. This adds an efficient paginator which first paginates by the `QuerySet` number used, and then by the normal `Cursor` pagination of Django REST Framework.

## TODO

* [x] Get tests passing
* [x] Add more tests to ensure the pagination is stable while adding/removing items.
* [x] Add documentation.