### PR TITLE
Fix exception string to include a missing word

### DIFF
--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -521,7 +521,7 @@ class QuerySetSequence(six.with_metaclass(PartialInheritanceMeta, QuerySet)):
 
             # Ensure this is being used to filter QuerySets.
             if parts[0] != '#':
-                raise ValueError("Keyword '%s' is not a valid to filter over, "
+                raise ValueError("Keyword '%s' is not a valid keyword to filter over, "
                                  "it must begin with '#'." % kwarg)
 
             # Don't allow __ multiple times.


### PR DESCRIPTION
Tiny change, the string was missing a word so the message was not clear.