### PR TITLE
Run tests on Django REST Framework 3.5.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ envlist =
     # Django REST Framework 3.2 added support for Django 1.8.
     {py27,py34,py35}-django18-drf32,
     # Django REST Framework 3.3, 3.4, and master support Django 1.8 and 1.9.
-    {py27,py34,py35}-django{18,19}-drf{33,34,master},
+    {py27,py34,py35}-django{18,19}-drf{33,34,35,master},
     # Django REST Framework 3.4 added support for Django 1.10.
-    {py27,py34,py35}-django{110,master}-drf{34,master}
+    {py27,py34,py35}-django{110,master}-drf{34,35,master}
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
Django REST Framework 3.5 was released.