### PR TITLE
Fix an issue where slicing of an individual QuerySet was broken.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 #########
 
+0.7.1 (2017-03-17)
+==================
+
+* [Bugfix] Slicing a ``QuerySetSequence`` did not work properly when the slice
+  reduced the ``QuerySetSequence`` to a single ``QuerySet``. See #23, #24.
+
 0.7 (2016-10-20)
 ================
 

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -224,13 +224,13 @@ class QuerySequence(six.with_metaclass(PartialInheritanceMeta, Query)):
         # from it.
         self.high_mark -= counts[end_index - 1]
 
+        # Some optimization, if there is only one QuerySet, iterate through it.
+        if len(self._querysets) == 1:
+            return iter(self._querysets[0][self.low_mark:self.high_mark])
+
         # Apply the offsets to the edge QuerySets.
         self._querysets[0] = self._querysets[0][self.low_mark:]
         self._querysets[-1] = self._querysets[-1][:self.high_mark]
-
-        # Some optimization, if there is only one QuerySet, iterate through it.
-        if len(self._querysets) == 1:
-            return iter(self._querysets[0])
 
         # For anything left, just chain the QuerySets together.
         return chain(*self._querysets)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def long_description():
 setup(
     name='django-querysetsequence',
     packages=find_packages(),
-    version='0.7',
+    version='0.7.1',
     description='Chain together multiple (disparate) QuerySets to treat them as a single QuerySet.',
     long_description=long_description(),
     author='Percipient Networks, LLC',

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1088,6 +1088,27 @@ class TestSlicing(TestBase):
         self.assertEqual(data[0], 'Biography')
         self.assertEqual(data[1], 'Django Rocks')
 
+    def test_open_slice(self):
+        """Test slicing without an end."""
+        articles = Article.objects.all()
+        qs = articles[1:]
+        qss = QuerySetSequence(articles)[1:]
+
+        self.assertEqual(len(qs), len(qss))
+        self.assertEqual(list(qs), list(qss))
+
+    def test_closed_slice_single_qs(self):
+        """Test slicing if the start and end are within the same QuerySet."""
+        Article.objects.create(title='Another Article', author=self.bob,
+                               publisher=self.mad_magazine)
+
+        articles = Article.objects.all()
+        qs = articles[1:3]
+        qss = QuerySetSequence(articles)[1:3]
+
+        # The length should be the same.
+        self.assertEqual(len(qs), len(qss))
+
 
 class TestGet(TestBase):
     def test_get(self):


### PR DESCRIPTION
This fixes #23 (and adds tests for it).

The fix is pretty much that if there's only a single `QuerySet` left, you need to slice both the start and end off at the same time, otherwise you trim improperly.