### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ notifications:
   email: false
 install:
   - pip install tox coveralls
+after_success:
+  - coveralls

--- a/run_coveralls.py
+++ b/run_coveralls.py
@@ -1,9 +1,0 @@
-#!/bin/env/python
-
-import os
-from subprocess import call
-
-
-if __name__ == '__main__':
-    if 'TRAVIS' in os.environ:
-        raise SystemExit(call('coveralls'))

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,10 @@ skip_missing_interpreters = True
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =
     coverage run manage.py test
-    python run_coveralls.py
+    coverage report
+    coverage html
 deps =
-    coveralls
+    coverage
     py27: mock
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,16 @@
 # versions, then combinations of Python versions with Django REST Framework
 # versions.
 envlist =
-    {py27,py34,py35}-django{18,19,110,master},
+    # Without Django REST Framework.
+    py27-django{18,19,110},
+    py{34,35,36}-django{18,19,110},
     # Django REST Framework 3.2 added support for Django 1.8.
-    {py27,py34,py35}-django18-drf32,
-    # Django REST Framework 3.3, 3.4, and master support Django 1.8 and 1.9.
-    {py27,py34,py35}-django{18,19}-drf{33,34,35,master},
+    py{27,34,35,36}-django18-drf32,
+    # Django REST Framework 3.3 added support for Django 1.9.
+    py{27,34,35,36}-django{18,19}-drf{33,34,35,36,master},
     # Django REST Framework 3.4 added support for Django 1.10.
-    {py27,py34,py35}-django{110,master}-drf{34,35,master}
+    py{27,34,35,36}-django{110}-drf{34,35,36,master}
+skip_missing_interpreters = True
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -27,8 +30,11 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11a,<2.0
     djangomaster: https://codeload.github.com/django/django/zip/master
     drf32: djangorestframework>=3.2,<3.3
     drf33: djangorestframework>=3.3,<3.4
     drf34: djangorestframework>=3.4,<3.5
+    drf35: djangorestframework>=3.5,<3.6
+    drf36: djangorestframework>=3.6,<3.7
     drfmaster: https://codeload.github.com/tomchristie/django-rest-framework/zip/master


### PR DESCRIPTION
Builds are failing since django-querysetsequence is not compatible with Django 1.11 (or master). I plan to fix this, but for now just don't test against those.