### PR TITLE
Fix raising NotImplementedError for methods with arguments.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 #########
 
+0.7.2 (2017-04-xx)
+==================
+
+* [Bugfix] Calling an unimplemented method with parameters on
+  ``QuerySetSequence`` raised a non-sensical error.
+
 0.7.1 (2017-03-31)
 ==================
 

--- a/queryset_sequence/_inheritance.py
+++ b/queryset_sequence/_inheritance.py
@@ -38,7 +38,7 @@ class PartialInheritanceMeta(type):
 
             # For each not implemented attribute, add a method raising
             # NotImplementedError.
-            def not_impl(attr):
+            def not_impl(attr, *args, **kwargs):
                 raise NotImplementedError("%s does not implement %s()" %
                                           (name, attr))
 

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -15,6 +15,10 @@ class A(object):
     def e(self):
         return 17
 
+    def g(self, arg):
+        """A method with an argument."""
+        return 24
+
     def __init__(self):
         self.z = 42
 
@@ -24,7 +28,7 @@ class A(object):
 
 class B(six.with_metaclass(PartialInheritanceMeta, A)):
     INHERITED_ATTRS = ['a', 'e']
-    NOT_IMPLEMENTED_ATTRS = ['b', 'd']
+    NOT_IMPLEMENTED_ATTRS = ['b', 'd', 'g']
 
     f = True
 
@@ -69,6 +73,7 @@ class TestPartialInheritanceMeta(TestCase):
         self.assertEqual(self.b.y, 24)
 
     def test_not_implemented(self):
+        """An attribute that is marked as not implemented raises the proper exception."""
         self.assertTrue(hasattr(self.a, 'b'))
         self.assertEqual(self.a.b, True)
 
@@ -77,6 +82,17 @@ class TestPartialInheritanceMeta(TestCase):
             self.b.b()
         self.assertExceptionMessageEquals(exc.exception,
                                           'B does not implement b()')
+
+    def test_not_implemented_args(self):
+        """A method (with arguments) that is marked as not implemented raises the proper exception."""
+        self.assertTrue(hasattr(self.a, 'g'))
+        self.assertEqual(self.a.g(1), 24)
+
+        self.assertTrue(hasattr(self.b, 'g'))
+        with self.assertRaises(NotImplementedError) as exc:
+            self.b.g(1)
+        self.assertExceptionMessageEquals(exc.exception,
+                                          'B does not implement g()')
 
     def test_attr_error(self):
         self.assertTrue(hasattr(self.a, 'c'))


### PR DESCRIPTION
If you try to call a method that is marked as "not implemented" that has parameters the current code explodes with a non-helpful error message. This fixes it so you get the "QuerySetSequence does not implement <whatever>()".

Fixes #27