### PR TITLE
Add optimization for not sliced querysets

### DIFF
--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -179,6 +179,10 @@ class QuerySequence(six.with_metaclass(PartialInheritanceMeta, Query)):
         # If there is no ordering, or the ordering is specific to each QuerySet,
         # evaluation can be pushed off further.
 
+        # Some optimization, if there is no slicing, iterate through querysets.
+        if self.low_mark == 0 and self.high_mark is None:
+            return chain(*self._querysets)
+
         # First trim any QuerySets based on the currently set limits!
         counts = [0]
         counts.extend(cumsum([it.count() for it in self._querysets]))

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -211,11 +211,11 @@ class TestIterator(TestBase):
         qss = self.all._clone()
 
         # Ensure that calling iterator twice re-evaluates the query.
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             data = [it.title for it in qss.iterator()]
             self.assertEqual(data, TestIterator.EXPECTED)
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             data = [it.title for it in qss.iterator()]
             self.assertEqual(data, TestIterator.EXPECTED)
 
@@ -228,7 +228,7 @@ class TestIterator(TestBase):
         """Ensure that iterating the QuerySet caches."""
         qss = self.all._clone()
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             data = [it.title for it in qss]
             self.assertEqual(data, TestIterator.EXPECTED)
 
@@ -287,7 +287,8 @@ class TestAll(TestBase):
             "Alice in Django-land",
             "Some Article",
         ]
-        data = [it.title for it in copy]
+        with self.assertNumQueries(2):
+            data = [it.title for it in copy]
         self.assertEqual(data, expected)
 
         # The copy was evaluated, not qss.
@@ -298,14 +299,14 @@ class TestSelectRelated(TestBase):
     def test_select_related(self):
         # Check behavior first.
         qss = self.all._clone()
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             books = list(qss)
         with self.assertNumQueries(5):
             normal_authors = [b.author for b in books]
 
         # Now ensure no database query to get the author.
         qss = self.all._clone()
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             qss = qss.select_related('author')
             books = list(qss)
         with self.assertNumQueries(0):
@@ -317,14 +318,14 @@ class TestSelectRelated(TestBase):
     def test_clear_select_related(self):
         # Ensure no database query.
         qss = self.all._clone()
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             qss = qss.select_related('author')
             books = list(qss)
         with self.assertNumQueries(0):
             authors = [b.author for b in books]
 
         # Ensure there is a database query.
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             qss = qss.select_related(None)
             books = list(qss)
         with self.assertNumQueries(5):
@@ -336,14 +337,14 @@ class TestPrefetchRelated(TestBase):
     def test_prefetch_related(self):
         # Check behavior first, one database query per author access.
         qss = self.all._clone()
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             books = list(qss)
         with self.assertNumQueries(5):
             normal_authors = [b.author for b in books]
 
         # Now ensure one database query for all authors.
         qss = self.all._clone()
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(4):
             qss = qss.prefetch_related('author')
             books = list(qss)
         with self.assertNumQueries(0):
@@ -355,14 +356,14 @@ class TestPrefetchRelated(TestBase):
     def test_clear_prefetch_related(self):
         # Ensure no database query.
         qss = self.all._clone()
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(4):
             qss = qss.prefetch_related('author')
             books = list(qss)
         with self.assertNumQueries(0):
             authors = [b.author for b in books]
 
         # Ensure there is a database query.
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(2):
             qss = qss.prefetch_related(None)
             books = list(qss)
         with self.assertNumQueries(5):


### PR DESCRIPTION
It makes 2 times fewer queries because of `count()` calls. This
`count()` calls are quite inefficient when we use Postgres. They are
only required when slice (`set_limits`) is used.