### PR TITLE
Support Django 1.11 & 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 # This version of python is only used to run tox.
-python: 3.5
+python: 3.6
 script: tox
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -278,7 +278,7 @@ Requirements
 ============
 
 * Python (2.7, 3.4, 3.5, 3.6)
-* Django (1.8, 1.9, 1.10, 1.11)
+* Django (1.8, 1.10, 1.11)
 * (Optionally) Django REST Framework (3.2, 3.3, 3.4, 3.5, 3.6)
 
 .. list-table:: ``QuerySetSequence`` versions with support for Django/Django REST Framework
@@ -287,21 +287,17 @@ Requirements
 
     * -
       - Django 1.8
-      - Django 1.9
       - Django 1.10
       - Django 1.11
     * - Django REST Framework 3.2
       - 0.7
       - |xmark|
       - |xmark|
-      - |xmark|
     * - Django REST Framework 3.3
-      - 0.7
       - 0.7
       - |xmark|
       - |xmark|
     * - Django REST Framework 3.4
-      - 0.7
       - 0.7
       - 0.7
       - 0.7.1
@@ -309,9 +305,7 @@ Requirements
       - 0.7.1
       - 0.7.1
       - 0.7.1
-      - 0.7.1
     * - Django REST Framework 3.6
-      - 0.7.1
       - 0.7.1
       - 0.7.1
       - 0.7.1

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -45,7 +45,7 @@ def cumsum(seq):
 # iterator.
 class SequenceIterable(object):
     def __init__(self, queryset, *args, **kwargs):
-        self.queryset = queryset
+        self.queryset = queryset._clone()
 
     def __iter__(self):
         return iter(self.queryset.query)

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -116,6 +116,12 @@ class QuerySequence(six.with_metaclass(PartialInheritanceMeta, Query)):
         """Return the class-name and memory location; there's no SQL to show."""
         return object.__str__(self)
 
+    def chain(self, *args, **kwargs):
+        obj = super(QuerySequence, self).chain(*args, **kwargs)
+
+        obj._querysets = [qs._chain() for qs in self._querysets]
+        return obj
+
     def clone(self, *args, **kwargs):
         obj = super(QuerySequence, self).clone(*args, **kwargs)
 
@@ -425,6 +431,7 @@ class QuerySetSequence(six.with_metaclass(PartialInheritanceMeta, QuerySet)):
         'db',
 
         # Private methods.
+        '_chain',
         '_clone',
         '_fetch_all',
         '_merge_sanity_check',

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -891,11 +891,16 @@ class TestOrderBy(TestBase):
 
     def test_order_by_queryset(self):
         """Ensure we can order by QuerySet and then other fields."""
+        from django import VERSION as DJANGO_VERSION
+
         # Order by title, but don't interleave each QuerySet.
         with self.assertNumQueries(0):
             qss = self.all.order_by('#', 'title')
         self.assertEqual(qss.query.order_by, ['#', 'title'])
-        self.assertEqual(qss.query._querysets[0].query.order_by, ['title'])
+        self.assertEqual(
+            qss.query._querysets[0].query.order_by,
+            ('title',) if DJANGO_VERSION >= (2,) else ['title'],
+        )
 
         # Ensure that _ordered_iterator isn't called.
         with patch('queryset_sequence.QuerySequence._ordered_iterator',
@@ -920,12 +925,17 @@ class TestOrderBy(TestBase):
         Note that this is *NOT* the same as calling reverse(), as that results
         the contents of each QuerySet as well.
         """
+        from django import VERSION as DJANGO_VERSION
+
         # Order by title, but don't interleave each QuerySet. And reverse
         # QuerySets.
         with self.assertNumQueries(0):
             qss = self.all.order_by('-#', 'title')
         self.assertEqual(qss.query.order_by, ['-#', 'title'])
-        self.assertEqual(qss.query._querysets[0].query.order_by, ['title'])
+        self.assertEqual(
+            qss.query._querysets[0].query.order_by,
+            ('title',) if DJANGO_VERSION >= (2,) else ['title'],
+        )
 
         # Ensure that _ordered_iterator isn't called.
         with patch('queryset_sequence.QuerySequence._ordered_iterator',

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     py27: mock
     django18: Django>=1.8,<1.9
     django110: Django>=1.10,<1.11
-    django111: Django>=1.11a,<2.0
+    django111: Django>=1.11,<2.0
     djangomaster: https://codeload.github.com/django/django/zip/master
     drf32: djangorestframework>=3.2,<3.3
     drf33: djangorestframework>=3.3,<3.4

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,10 @@
 # versions.
 envlist =
     # Without Django REST Framework.
-    py27-django{18,19,110,111},
-    py{34,35,36}-django{18,19,110,111,master},
+    py27-django{18,110,111},
+    py{34,35,36}-django{18,110,111,master},
     # Django REST Framework 3.2 added support for Django 1.8.
-    py{27,34,35,36}-django18-drf32,
-    # Django REST Framework 3.3 added support for Django 1.9.
-    py{27,34,35,36}-django{18,19}-drf{33,34,35,36,master},
+    py{27,34,35,36}-django18-drf{32,33,34,35,36,master},
     # Django REST Framework 3.4 added support for Django 1.10.
     py{27,34,35,36}-django{110,111}-drf{34,35,36,master},
     py{34,35,36}-django{master}-drf{34,35,36,master}
@@ -30,7 +28,6 @@ deps =
     coverage
     py27: mock
     django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11a,<2.0
     djangomaster: https://codeload.github.com/django/django/zip/master

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envlist =
     py{27,34,35,36}-django18-drf{32,33,34,35,36,master},
     # Django REST Framework 3.4 added support for Django 1.10.
     py{27,34,35,36}-django{110,111}-drf{34,35,36,master},
-    py{34,35,36}-django{master}-drf{34,35,36,master}
+    py{34,35,36}-django{master}-drf{36,master}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Tests are still failing, because Django master is not supported.
https://travis-ci.org/michael-k/django-querysetsequence/builds/267246035