### PR TITLE
Drop support for Django < 1.11 and corresponding DRF versions.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 ================
 
 * [Enhancement] Officially support Django REST Framework 3.7.
+* [Enhancement] Officially support Django 2.0.
 * [Incompatible change] Drop support for Django < 1.11. Django 1.11 and above
   are supported. This also drops support for Django REST Framework < 3.4, which
   since they do not support Django 1.11.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,13 @@
 Changelog
 #########
 
-0.8.1 (2017-xx-xx)
-==================
+0.9 (2018-xx-xx)
+================
 
 * [Enhancement] Officially support Django REST Framework 3.7.
+* [Incompatible change] Drop support for Django < 1.11. Django 1.11 and above
+  are supported. This also drops support for Django REST Framework < 3.4, which
+  since they do not support Django 1.11.
 
 0.8 (2017-09-05)
 ================

--- a/README.rst
+++ b/README.rst
@@ -293,48 +293,8 @@ Requirements
 ============
 
 * Python (2.7, 3.4, 3.5, 3.6)
-* Django (1.8, 1.9, 1.10, 1.11, 2.0)
-* (Optionally) `Django REST Framework`_ (3.2, 3.3, 3.4, 3.5, 3.6, 3.7)
-
-.. list-table:: ``QuerySetSequence`` versions with support for Django/Django REST Framework
-    :header-rows: 1
-    :stub-columns: 1
-
-    * -
-      - Django 1.8
-      - Django 1.9
-      - Django 1.10
-      - Django 1.11
-    * - Django REST Framework 3.2
-      - 0.7
-      - |xmark|
-      - |xmark|
-      - |xmark|
-    * - Django REST Framework 3.3
-      - 0.7
-      - 0.7
-      - |xmark|
-      - |xmark|
-    * - Django REST Framework 3.4
-      - 0.7
-      - 0.7
-      - 0.7
-      - 0.7.1
-    * - Django REST Framework 3.5
-      - 0.7.1
-      - 0.7.1
-      - 0.7.1
-      - 0.7.1
-    * - Django REST Framework 3.6
-      - 0.8
-      - 0.8
-      - 0.8
-      - 0.8
-    * - Django REST Framework 3.7
-      - |xmark|
-      - |xmark|
-      - 0.8
-      - 0.8
+* Django (1.11, 2.0)
+* (Optionally) `Django REST Framework`_ (3.4, 3.5, 3.6, 3.7)
 
 .. _Django REST Framework: http://www.django-rest-framework.org/
 

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -440,6 +440,7 @@ class QuerySetSequence(six.with_metaclass(PartialInheritanceMeta, QuerySet)):
         '_fetch_all',
         '_merge_sanity_check',
         '_prepare',
+        '_iterator',
     ]
     NOT_IMPLEMENTED_ATTRS = [
         # Public methods that return QuerySets.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 -e .
 
 # Not tested with older versions of Django.
-Django>=1.8.0
+Django>=1.11
 mock

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
     ],
     install_requires=[
-        'django>=1.8.0',
+        'django>=1.11',
     ],
 )

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -903,7 +903,7 @@ class TestOrderBy(TestBase):
         )
 
         # Ensure that _ordered_iterator isn't called.
-        with patch('queryset_sequence.QuerySequence._ordered_iterator',
+        with patch('queryset_sequence.QuerySequenceIterable._ordered_iterator',
                    side_effect=AssertionError('_ordered_iterator should not be called')):
             # Check the titles are properly ordered.
             data = [it.title for it in qss]
@@ -936,7 +936,7 @@ class TestOrderBy(TestBase):
         )
 
         # Ensure that _ordered_iterator isn't called.
-        with patch('queryset_sequence.QuerySequence._ordered_iterator',
+        with patch('queryset_sequence.QuerySequenceIterable._ordered_iterator',
                    side_effect=AssertionError('_ordered_iterator should not be called')):
             # Check the titles are properly ordered.
             data = [it.title for it in qss]

--- a/tox.ini
+++ b/tox.ini
@@ -9,18 +9,14 @@
 # versions.
 envlist =
     # Without Django REST Framework.
-    py{27,34,36}-django{18,19,110,111},
+    py{27,34,36}-django111,
     # Django 2.0 drops support for Python 2.7.
     py{34,36}-django20,
     # Django 2.1 drops support for Python 3.4.
     py36-djangomaster,
-    # Django REST Framework 3.2 added support for Django 1.8.
-    py{27,34,36}-django18-drf32,
-    # Django REST Framework 3.3 added support for Django 1.9.
-    py{27,34,36}-django{18,19}-drf{33,34,35,36,master},
     # Django REST Framework 3.4 added support for Django 1.10.
     # Django REST Framework 3.7 added support for Django 2.0, dropped support for Django 1.8 and 1.9.
-    py{27,34,36}-django{110,111}-drf{34,35,36,37,master},
+    py{27,34,36}-django111-drf{34,35,36,37,master},
     py{34,36}-django20-drf{37,master},
     py36-djangomaster-drf{37,master}
 skip_missing_interpreters = True
@@ -34,14 +30,9 @@ commands =
 deps =
     coverage
     py27: mock
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     djangomaster: https://codeload.github.com/django/django/zip/master
-    drf32: djangorestframework>=3.2,<3.3
-    drf33: djangorestframework>=3.3,<3.4
     drf34: djangorestframework>=3.4,<3.5
     drf35: djangorestframework>=3.5,<3.6
     drf36: djangorestframework>=3.6,<3.7


### PR DESCRIPTION
This drops support for [unsupported Django versions](https://www.djangoproject.com/download/#supported-versions) (1.8, 1.9, and 1.10) and the corresponding Django REST Framework versions (3.2 and 3.3).

Django 1.8 is actually supported for a couple more months (through April, 2018), but there's some clean-up that can happen by dropping it.