### PR TITLE
Support first() and last()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,10 +145,10 @@ multiple ``QuerySets``:
       - |xmark|
       - 
     * - |first|_
-      - |xmark|
+      - |check|
       - 
     * - |last|_
-      - |xmark|
+      - |check|
       - 
     * - |aggregate|_
       - |xmark|

--- a/README.rst
+++ b/README.rst
@@ -146,10 +146,13 @@ multiple ``QuerySets``:
       - 
     * - |first|_
       - |check|
-      - 
+      - If no ordering is set this is essentially the same as calling
+        ``first()`` on the first ``QuerySet``, if there is an ordering, the
+        result of ``first()`` for each ``QuerySet`` is compared and the "first"
+        returned.
     * - |last|_
       - |check|
-      - 
+      - See the documentation for ``first()``.
     * - |aggregate|_
       - |xmark|
       - 

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -39,16 +39,7 @@ def cumsum(seq):
         yield s
 
 
-class QuerySequenceIterable(object):
-    def __init__(self, querysetsequence):
-        # Create a clone so that subsequent calls to iterate are kept separate.
-        self._querysets = querysetsequence._querysets
-        self._queryset_idxs = querysetsequence._queryset_idxs
-        self._order_by = querysetsequence._order_by
-        self._standard_ordering = querysetsequence._standard_ordering
-        self._low_mark = querysetsequence._low_mark
-        self._high_mark = querysetsequence._high_mark
-
+class ComparatorMixin(object):
     @classmethod
     def _get_field_names(cls, model):
         """Return a list of field names that are part of a model."""
@@ -129,6 +120,17 @@ class QuerySequenceIterable(object):
                 return 0
 
         return comparator
+
+
+class QuerySequenceIterable(ComparatorMixin):
+    def __init__(self, querysetsequence):
+        # Create a clone so that subsequent calls to iterate are kept separate.
+        self._querysets = querysetsequence._querysets
+        self._queryset_idxs = querysetsequence._queryset_idxs
+        self._order_by = querysetsequence._order_by
+        self._standard_ordering = querysetsequence._standard_ordering
+        self._low_mark = querysetsequence._low_mark
+        self._high_mark = querysetsequence._high_mark
 
     def _ordered_iterator(self):
         """
@@ -291,7 +293,7 @@ class QuerySequenceIterable(object):
         return self._unordered_iterator()
 
 
-class QuerySetSequence(object):
+class QuerySetSequence(ComparatorMixin):
     """
     Wrapper for multiple QuerySets without the restriction on the identity of
     the base models.
@@ -569,14 +571,44 @@ class QuerySetSequence(object):
         return clone
 
     def first(self):
+        # If there's no QuerySets, return None. If the QuerySets are unordered,
+        # use the first item of first QuerySet. If ordered, compare the first
+        # item of each QuerySet to find the overall first.
         if not self._querysets:
             return None
-        return self._querysets[0].first()
+
+        elif not self.ordered:
+            return self._querysets[0].first()
+
+        else:
+            # Get each first item.
+            items = [qs.first() for qs in self._querysets]
+
+            # Generate a comparator and sort the items.
+            comparator = self._generate_comparator(self._order_by)
+            items = sorted(items, key=functools.cmp_to_key(comparator))
+
+            # Return the first one.
+            return items[0]
 
     def last(self):
+        # See the comments for first().
         if not self._querysets:
             return None
-        return self._querysets[-1].last()
+
+        elif not self.ordered:
+            return self._querysets[-1].last()
+
+        else:
+            # Get each last item.
+            items = [qs.last() for qs in self._querysets]
+
+            # Generate a comparator and sort the items.
+            comparator = self._generate_comparator(self._order_by)
+            items = sorted(items, key=functools.cmp_to_key(comparator))
+
+            # Return the first one.
+            return items[-1]
 
     def exists(self):
         return any(qs.exists() for qs in self._querysets)

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -568,6 +568,16 @@ class QuerySetSequence(object):
         clone._querysets = [qs.iterator() for qs in self._querysets]
         return clone
 
+    def first(self):
+        if not self._querysets:
+            return None
+        return self._querysets[0].first()
+
+    def last(self):
+        if not self._querysets:
+            return None
+        return self._querysets[-1].last()
+
     def exists(self):
         return any(qs.exists() for qs in self._querysets)
 

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1128,12 +1128,12 @@ class TestBoolean(TestBase):
 
 
 class TestFirstLast(TestBase):
-    def test_first(self):
+    def test_first_unordered(self):
         """Should return the first element of the first QuerySet."""
         with self.assertNumQueries(1):
             self.assertEqual(self.all.first().title, 'Fiction')
 
-    def test_last(self):
+    def test_last_unordered(self):
         """Should return the last element of the last QuerySet."""
         with self.assertNumQueries(1):
             self.assertEqual(self.all.last().title, 'Some Article')
@@ -1142,6 +1142,24 @@ class TestFirstLast(TestBase):
         """Empty QuerySetSequence should work."""
         qs = QuerySetSequence()
         self.assertIsNone(qs.first())
+
+    def test_first_ordered(self):
+        """When ordering, the items of each QuerySet must be compared."""
+        # Order by author and ensure it takes.
+        with self.assertNumQueries(2):
+            self.assertEqual(self.all.order_by('title').first().title, 'Alice in Django-land')
+
+        with self.assertNumQueries(2):
+            self.assertEqual(self.all.order_by('-title').first().title, 'Some Article')
+
+    def test_last_ordered(self):
+        """When ordering, the items of each QuerySet must be compared."""
+        # Order by author and ensure it takes.
+        with self.assertNumQueries(2):
+            self.assertEqual(self.all.order_by('-title').last().title, 'Alice in Django-land')
+
+        with self.assertNumQueries(2):
+            self.assertEqual(self.all.order_by('title').last().title, 'Some Article')
 
 
 class TestExists(TestBase):

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1127,6 +1127,23 @@ class TestBoolean(TestBase):
             self.assertTrue(self.all.filter(author=self.bob))
 
 
+class TestFirstLast(TestBase):
+    def test_first(self):
+        """Should return the first element of the first QuerySet."""
+        with self.assertNumQueries(1):
+            self.assertEqual(self.all.first().title, 'Fiction')
+
+    def test_last(self):
+        """Should return the last element of the last QuerySet."""
+        with self.assertNumQueries(1):
+            self.assertEqual(self.all.last().title, 'Some Article')
+
+    def test_empty(self):
+        """Empty QuerySetSequence should work."""
+        qs = QuerySetSequence()
+        self.assertIsNone(qs.first())
+
+
 class TestExists(TestBase):
     def test_exists(self):
         """Ensure that exists() returns True if the item is found in the first QuerySet."""


### PR DESCRIPTION
Add support for calling `first()` and `last()`. These take into account ordering and compare the `first()` (or `last()`) of each individual `QuerySet`.