### PR TITLE
Re-implement NotImplementedError

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,7 @@ multiple ``QuerySets``:
   iteration, slicing, pickling, ``repr()``/``len()``/``list()``/``bool()``
   calls).
 * Public ``QuerySet`` API methods that are untested/unimplemented raise
-  ``NotImplementedError``. ``AttributeError`` is raised on attributes not
-  explictly inherited from ``QuerySet``.
+  ``NotImplementedError``.
 
 .. Auto-generated content, run python gen_docs.py to generate this.
 .. ATTRIBUTES_TABLE_START

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -501,6 +501,9 @@ class QuerySetSequence(ComparatorMixin):
         clone._querysets = [qs.exclude(**fields) for qs in clone._querysets]
         return clone
 
+    def annotate(self, *args, **kwargs):
+        raise NotImplementedError()
+
     def order_by(self, *fields):
         _, filtered_fields = self._separate_fields(*fields)
 
@@ -518,6 +521,21 @@ class QuerySetSequence(ComparatorMixin):
         clone._standard_ordering = not self._standard_ordering
         return clone
 
+    def distinct(self, *fields):
+        raise NotImplementedError()
+
+    def values(self, *fields, **expressions):
+        raise NotImplementedError()
+
+    def values_list(self, *fields, **kwargs):
+        raise NotImplementedError()
+
+    def dates(self, field, kind, order='ASC'):
+        raise NotImplementedError()
+
+    def datetimes(self, field_name, kind, order='ASC', tzinfo=None):
+        raise NotImplementedError()
+
     def none(self):
         # This is a bit odd, but use the first QuerySet to properly return an
         # that is an instance of EmptyQuerySet.
@@ -528,6 +546,15 @@ class QuerySetSequence(ComparatorMixin):
         clone._querysets = [qs.all() for qs in self._querysets]
         return clone
 
+    def union(self, *other_qs, **kwargs):
+        raise NotImplementedError()
+
+    def intersection(self, *other_qs, **kwargs):
+        raise NotImplementedError()
+
+    def difference(self, *other_qs, **kwargs):
+        raise NotImplementedError()
+
     def select_related(self, *fields):
         clone = self._clone()
         clone._querysets = [qs.select_related(*fields) for qs in self._querysets]
@@ -537,6 +564,24 @@ class QuerySetSequence(ComparatorMixin):
         clone = self._clone()
         clone._querysets = [qs.prefetch_related(*lookups) for qs in self._querysets]
         return clone
+
+    def extra(self, select=None, where=None, params=None, tables=None, order_by=None, select_params=None):
+        raise NotImplementedError()
+
+    def defer(self, *fields):
+        raise NotImplementedError()
+
+    def only(self, *fields):
+        raise NotImplementedError()
+
+    def using(self, alias):
+        raise NotImplementedError()
+
+    def select_for_update(self):
+        raise NotImplementedError()
+
+    def raw(self):
+        raise NotImplementedError()
 
     # Methods that do not return QuerySets
     def get(self, **kwargs):
@@ -562,8 +607,23 @@ class QuerySetSequence(ComparatorMixin):
         # Return the only result found.
         return result
 
+    def create(self, **kwargs):
+        raise NotImplementedError()
+
+    def get_or_create(self, defaults=None, **kwargs):
+        raise NotImplementedError()
+
+    def update_or_create(self, defaults=None, **kwargs):
+        raise NotImplementedError()
+
+    def bulk_create(self, objs, batch_size=None, ignore_conflicts=False):
+        raise NotImplementedError()
+
     def count(self):
         return sum(qs.count() for qs in self._querysets) - self._low_mark
+
+    def in_bulk(self, id_list=None, field_name='pk'):
+        raise NotImplementedError()
 
     def iterator(self):
         clone = self._clone()
@@ -578,6 +638,12 @@ class QuerySetSequence(ComparatorMixin):
         # Return the first one (whether this is first or last is controlled by
         # reverse).
         return items[0]
+
+    def latest(self, *fields):
+        raise NotImplementedError()
+
+    def earliest(self, *fields):
+        raise NotImplementedError()
 
     def first(self):
         # If there's no QuerySets, return None. If the QuerySets are unordered,
@@ -607,8 +673,14 @@ class QuerySetSequence(ComparatorMixin):
             return self._get_first_or_last(
                 [qs.last() for qs in self._querysets], True)
 
+    def aggregate(self, *args, **kwargs):
+        raise NotImplementedError()
+
     def exists(self):
         return any(qs.exists() for qs in self._querysets)
+
+    def update(self, **kwargs):
+        raise NotImplementedError()
 
     def delete(self):
         deleted_count = 0
@@ -625,7 +697,10 @@ class QuerySetSequence(ComparatorMixin):
         return deleted_count, dict(deleted_objects)
 
     def as_manager(self):
-        pass
+        raise NotImplementedError()
+
+    def explain(self):
+        raise NotImplementedError()
 
     # Public attributes
     @property

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1204,3 +1204,115 @@ class TestDelete(TestBase):
 
         with self.assertNumQueries(2):
             self.assertEqual(self.all.count(), 3)
+
+
+class TestCannotImplement(TestCase):
+    """The following methods cannot be implemented in QuerySetSequence."""
+    def setUp(self):
+        self.all = QuerySetSequence()
+
+    def test_annotate(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.annotate()
+
+    def test_distinct(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.distinct()
+
+    def test_values(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.values()
+
+    def test_values_list(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.values_list()
+
+    def test_dates(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.dates(None, None)
+
+    def test_datetimes(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.datetimes(None, None)
+
+    def test_union(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.union()
+
+    def test_intersection(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.intersection()
+
+    def test_difference(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.difference()
+
+    def test_extra(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.extra()
+
+    def test_defer(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.defer()
+
+    def test_only(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.only()
+
+    def test_using(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.using('default')
+
+    def test_select_for_update(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.select_for_update()
+
+    def test_raw(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.raw()
+
+    def test_create(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.create()
+
+    def test_get_or_create(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.get_or_create()
+
+    def test_update_or_create(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.update_or_create()
+
+    def test_bulk_create(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.bulk_create([])
+
+    def test_in_bulk(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.in_bulk()
+
+    def test_update(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.update()
+
+
+class TestNotImplemented(TestCase):
+    """The following methods have not been implemented in QuerySetSequence."""
+    def setUp(self):
+        self.all = QuerySetSequence()
+
+    def test_latest(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.latest()
+
+    def test_earliest(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.earliest()
+
+    def test_aggregate(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.aggregate()
+
+    def test_explain(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.explain()


### PR DESCRIPTION
When switching to not inheriting from `QuerySet` (and removing the inheritance helpers), we no longer raise `NotImplementedError` for methods that aren't implemented. This is nicer than just raising `AttributeError` in those cases.