### PR TITLE
Add support for defer(), only(), and using()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ next (2018-xx-xx)
 
 * [Enhancement] Support ``first()`` and ``last()`` methods.
 * [Enhancement] Support the ``&`` and ``|`` operators.
+* [Enhancement] Support ``defer()`` method.
 * [Bugfix] Raise ``NotImplementedError`` on unimplemented methods. This fixes a
   regression introduced in 0.9.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ next (2018-xx-xx)
 
 * [Enhancement] Support ``first()`` and ``last()`` methods.
 * [Enhancement] Support the ``&`` and ``|`` operators.
-* [Enhancement] Support ``defer()`` method.
+* [Enhancement] Support ``defer()`` and ``only()`` methods.
 * [Bugfix] Raise ``NotImplementedError`` on unimplemented methods. This fixes a
   regression introduced in 0.9.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ next (2018-xx-xx)
 * [Enhancement] Support ``first()`` and ``last()`` methods.
 * [Enhancement] Support the ``&`` and ``|`` operators.
 * [Enhancement] Support ``defer()`` and ``only()`` methods.
+* [Enhancement] Support calling ``using()`` to switch databases for an entire
+  ``QuerySetSequence``.
 * [Bugfix] Raise ``NotImplementedError`` on unimplemented methods. This fixes a
   regression introduced in 0.9.
 

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ multiple ``QuerySets``:
       - |check|
       -
     * - |only|_
-      - |xmark|
+      - |check|
       -
     * - |using|_
       - |xmark|

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ multiple ``QuerySets``:
       - |xmark|
       -
     * - |defer|_
-      - |xmark|
+      - |check|
       -
     * - |only|_
       - |xmark|

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ multiple ``QuerySets``:
       - |check|
       -
     * - |using|_
-      - |xmark|
+      - |check|
       -
     * - |select_for_update|_
       - |xmark|

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -612,7 +612,9 @@ class QuerySetSequence(ComparatorMixin):
         return clone
 
     def only(self, *fields):
-        raise NotImplementedError()
+        clone = self._clone()
+        clone._querysets = [qs.only(*fields) for qs in self._querysets]
+        return clone
 
     def using(self, alias):
         raise NotImplementedError()

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -607,7 +607,9 @@ class QuerySetSequence(ComparatorMixin):
         raise NotImplementedError()
 
     def defer(self, *fields):
-        raise NotImplementedError()
+        clone = self._clone()
+        clone._querysets = [qs.defer(*fields) for qs in self._querysets]
+        return clone
 
     def only(self, *fields):
         raise NotImplementedError()

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -617,7 +617,9 @@ class QuerySetSequence(ComparatorMixin):
         return clone
 
     def using(self, alias):
-        raise NotImplementedError()
+        clone = self._clone()
+        clone._querysets = [qs.using(alias) for qs in self._querysets]
+        return clone
 
     def select_for_update(self):
         raise NotImplementedError()

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -439,6 +439,22 @@ class TestDeferOnly(TestBase):
         self.empty.only('publisher')
 
 
+class TestUsing(TestBase):
+    EXPECTED = [
+        "Fiction",
+        "Biography",
+        "Django Rocks",
+        "Alice in Django-land",
+        "Some Article",
+    ]
+
+    def test_using(self):
+        """Using should be passed through to each QuerySet."""
+        with self.assertNumQueries(2):
+            titles = [b.title for b in self.all.using('default')]
+        self.assertEqual(titles, self.EXPECTED)
+
+
 class TestFilter(TestBase):
     def test_filter(self):
         """
@@ -1468,10 +1484,6 @@ class TestCannotImplement(TestCase):
     def test_extra(self):
         with self.assertRaises(NotImplementedError):
             self.all.extra()
-
-    def test_using(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.using('default')
 
     def test_select_for_update(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
These simply pass through to the internal `QuerySet` instances.