### PR TITLE
Support calling update()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ next (2018-xx-xx)
 * [Enhancement] Support ``defer()`` and ``only()`` methods.
 * [Enhancement] Support calling ``using()`` to switch databases for an entire
   ``QuerySetSequence``.
+* [Enhancement] Support calling ``update()``.
 * [Bugfix] Raise ``NotImplementedError`` on unimplemented methods. This fixes a
   regression introduced in 0.9.
 

--- a/README.rst
+++ b/README.rst
@@ -192,8 +192,8 @@ multiple ``QuerySets``:
       - |check|
       -
     * - |update|_
-      - |xmark|
-      - Cannot be implemented in ``QuerySetSequence``.
+      - |check|
+      -
     * - |delete|_
       - |check|
       -

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -724,7 +724,7 @@ class QuerySetSequence(ComparatorMixin):
         return any(qs.exists() for qs in self._querysets)
 
     def update(self, **kwargs):
-        raise NotImplementedError()
+        return sum(qs.update(**kwargs) for qs in self._querysets)
 
     def delete(self):
         deleted_count = 0

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -7,6 +7,7 @@ from operator import __not__, attrgetter, eq, ge, gt, le, lt, mul
 
 from django.core.exceptions import (FieldError, MultipleObjectsReturned,
                                     ObjectDoesNotExist)
+from django.db import transaction
 from django.db.models.base import Model
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query import EmptyQuerySet, QuerySet
@@ -724,7 +725,8 @@ class QuerySetSequence(ComparatorMixin):
         return any(qs.exists() for qs in self._querysets)
 
     def update(self, **kwargs):
-        return sum(qs.update(**kwargs) for qs in self._querysets)
+        with transaction.atomic():
+            return sum(qs.update(**kwargs) for qs in self._querysets)
 
     def delete(self):
         deleted_count = 0

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1310,6 +1310,23 @@ class TestExists(TestBase):
         self.assertFalse(self.empty.exists())
 
 
+class TestUpdate(TestBase):
+    def test_update(self):
+        """Update should apply across all QuerySets."""
+        with self.assertNumQueries(2):
+            result = self.all.update(title='A New Title')
+        self.assertEqual(result, 5)
+
+        with self.assertNumQueries(2):
+            data = [it.title for it in self.all]
+        self.assertEqual(data, ['A New Title'] * 5)
+
+    def test_empty(self):
+        """Calling delete on an empty QuerySetSequence should work."""
+        result = self.empty.update()
+        self.assertEqual(result, 0)
+
+
 class TestDelete(TestBase):
     def test_delete_all(self):
         """Ensure that delete() works properly."""
@@ -1428,10 +1445,6 @@ class TestNotImplemented(TestCase):
     def test_aggregate(self):
         with self.assertRaises(NotImplementedError):
             self.all.aggregate()
-
-    def test_update(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.update()
 
     def test_explain(self):
         with self.assertRaises(NotImplementedError):

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1343,6 +1343,32 @@ class TestCannotImplement(TestCase):
     def setUp(self):
         self.all = QuerySetSequence()
 
+    def test_create(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.create()
+
+    def test_get_or_create(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.get_or_create()
+
+    def test_update_or_create(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.update_or_create()
+
+    def test_bulk_create(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.bulk_create([])
+
+    def test_in_bulk(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.in_bulk()
+
+
+class TestNotImplemented(TestCase):
+    """The following methods have not been implemented in QuerySetSequence."""
+    def setUp(self):
+        self.all = QuerySetSequence()
+
     def test_annotate(self):
         with self.assertRaises(NotImplementedError):
             self.all.annotate()
@@ -1391,36 +1417,6 @@ class TestCannotImplement(TestCase):
         with self.assertRaises(NotImplementedError):
             self.all.raw()
 
-    def test_create(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.create()
-
-    def test_get_or_create(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.get_or_create()
-
-    def test_update_or_create(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.update_or_create()
-
-    def test_bulk_create(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.bulk_create([])
-
-    def test_in_bulk(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.in_bulk()
-
-    def test_update(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.update()
-
-
-class TestNotImplemented(TestCase):
-    """The following methods have not been implemented in QuerySetSequence."""
-    def setUp(self):
-        self.all = QuerySetSequence()
-
     def test_latest(self):
         with self.assertRaises(NotImplementedError):
             self.all.latest()
@@ -1432,6 +1428,10 @@ class TestNotImplemented(TestCase):
     def test_aggregate(self):
         with self.assertRaises(NotImplementedError):
             self.all.aggregate()
+
+    def test_update(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.update()
 
     def test_explain(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Support calling `update()`, which applies to all `QuerySets`. Updates are done in a transaction.