### PR TITLE
Add support for calling annotate()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,10 +8,11 @@ next (2018-xx-xx)
 
 * [Enhancement] Support ``first()`` and ``last()`` methods.
 * [Enhancement] Support the ``&`` and ``|`` operators.
-* [Enhancement] Support ``defer()`` and ``only()`` methods.
+* [Enhancement] Support ``defer()`` and ``only()`` methods to control which
+  fields are returned.
 * [Enhancement] Support calling ``using()`` to switch databases for an entire
   ``QuerySetSequence``.
-* [Enhancement] Support calling ``update()``.
+* [Enhancement] Support calling ``update()`` and ``annotate()``.
 * [Bugfix] Raise ``NotImplementedError`` on unimplemented methods. This fixes a
   regression introduced in 0.9.
 

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ multiple ``QuerySets``:
       - |check|
       - See [1]_ for information on the ``QuerySet`` lookup: ``'#'``.
     * - |annotate|_
-      - |xmark|
+      - |check|
       -
     * - |order_by|_
       - |check|

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -541,7 +541,9 @@ class QuerySetSequence(ComparatorMixin):
         return clone
 
     def annotate(self, *args, **kwargs):
-        raise NotImplementedError()
+        clone = self._clone()
+        clone._querysets = [qs.annotate(*args, **kwargs) for qs in clone._querysets]
+        return clone
 
     def order_by(self, *fields):
         _, filtered_fields = self._separate_fields(*fields)

--- a/tests/models.py
+++ b/tests/models.py
@@ -32,7 +32,7 @@ class OnlinePublisher(models.Model):
 class Article(models.Model):
     title = models.CharField(max_length=100)
     author = models.ForeignKey(Author, on_delete=models.CASCADE)
-    publisher = models.ForeignKey(PeriodicalPublisher, on_delete=models.CASCADE)
+    publisher = models.ForeignKey(PeriodicalPublisher, related_name='published', on_delete=models.CASCADE)
     release = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
@@ -42,13 +42,13 @@ class Article(models.Model):
 class BlogPost(models.Model):
     title = models.CharField(max_length=100)
     author = models.ForeignKey(Author, on_delete=models.CASCADE)
-    publisher = models.ForeignKey(OnlinePublisher, on_delete=models.CASCADE)
+    publisher = models.ForeignKey(OnlinePublisher, related_name='published', on_delete=models.CASCADE)
 
 
 class Book(models.Model):
     title = models.CharField(max_length=50)
     author = models.ForeignKey(Author, on_delete=models.CASCADE)
-    publisher = models.ForeignKey(Publisher, on_delete=models.CASCADE)
+    publisher = models.ForeignKey(Publisher, related_name='published', on_delete=models.CASCADE)
     release = models.DateTimeField(auto_now_add=True)
     pages = models.PositiveSmallIntegerField()
 


### PR DESCRIPTION
Adds support for calling `annotate()`, which simply passes through to the underlying `QuerySet` instances.