### PR TITLE
Support extra() as a method.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,8 @@ next (2018-xx-xx)
   fields are returned.
 * [Enhancement] Support calling ``using()`` to switch databases for an entire
   ``QuerySetSequence``.
-* [Enhancement] Support calling ``update()`` and ``annotate()``.
+* [Enhancement] Support calling ``extra()`, ``update()``, and ``annotate()``
+  which get applied to each ``QuerySet``.
 * [Bugfix] Raise ``NotImplementedError`` on unimplemented methods. This fixes a
   regression introduced in 0.9.
 

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ multiple ``QuerySets``:
       - |check|
       -
     * - |extra|_
-      - |xmark|
+      - |check|
       -
     * - |defer|_
       - |check|

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -607,7 +607,9 @@ class QuerySetSequence(ComparatorMixin):
         return clone
 
     def extra(self, select=None, where=None, params=None, tables=None, order_by=None, select_params=None):
-        raise NotImplementedError()
+        clone = self._clone()
+        clone._querysets = [qs.extra(select=select, where=where, params=params, tables=tables, order_by=order_by, select_params=select_params) for qs in self._querysets]
+        return clone
 
     def defer(self, *fields):
         clone = self._clone()

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -790,7 +790,15 @@ class TestExclude(TestBase):
         self.empty.exclude(title='')
 
 
-class TestAnnotate(TestBase):
+class TestExtraAnnotate(TestBase):
+    def test_extra(self):
+        """Calling extra() gets applied to each QuerySet."""
+        # Filter to just Bob's work.
+        with self.assertNumQueries(0):
+            bob_qss = self.all.extra(where=["author_id = '{}'".format(self.bob.id)])
+        with self.assertNumQueries(2):
+            self.assertEqual(bob_qss.count(), 3)
+
     def test_annotate(self):
         """Annotating should get applied to each QuerySet."""
         qss = QuerySetSequence(Publisher.objects.all(), PeriodicalPublisher.objects.all())
@@ -1446,10 +1454,6 @@ class TestNotImplemented(TestCase):
     def test_difference(self):
         with self.assertRaises(NotImplementedError):
             self.all.difference()
-
-    def test_extra(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.extra()
 
     def test_select_for_update(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Adds support for `extra()`, which just calls each `QuerySet`.