### PR TITLE
Support explain() on Django >= 2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ next (2018-xx-xx)
   ``QuerySetSequence``.
 * [Enhancement] Support calling ``extra()`, ``update()``, and ``annotate()``
   which get applied to each ``QuerySet``.
+* [Enhancement] Support calling ``explain()`` on Django >= 2.1.
 * [Bugfix] Raise ``NotImplementedError`` on unimplemented methods. This fixes a
   regression introduced in 0.9.
 

--- a/README.rst
+++ b/README.rst
@@ -201,8 +201,8 @@ multiple ``QuerySets``:
       - |check|
       -
     * - |explain|_
-      - |xmark|
-      -
+      - |check|
+      - Only available on Django >= 2.1.
 
 .. |filter| replace:: ``filter()``
 .. _filter: https://docs.djangoproject.com/en/dev/ref/models/querysets/#filter

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -5,6 +5,7 @@ import functools
 from itertools import dropwhile
 from operator import __not__, attrgetter, eq, ge, gt, le, lt, mul
 
+import django
 from django.core.exceptions import (FieldError, MultipleObjectsReturned,
                                     ObjectDoesNotExist)
 from django.db import transaction
@@ -749,8 +750,9 @@ class QuerySetSequence(ComparatorMixin):
     def as_manager(self):
         raise NotImplementedError()
 
-    def explain(self):
-        raise NotImplementedError()
+    if django.VERSION >= (2, 1):
+        def explain(self, format=None, **options):
+            return '\n'.join(qs.explain() for qs in self._querysets)
 
     # Public attributes
     @property

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
-from unittest import skip
+from unittest import skip, skipIf
 
+import django
 from django.core.exceptions import (FieldDoesNotExist,
                                     FieldError,
                                     MultipleObjectsReturned,
@@ -1392,6 +1393,21 @@ class TestDelete(TestBase):
         self.assertEqual(result[1], {})
 
 
+class TestExplain(TestBase):
+    @skipIf(django.VERSION >= (2, 1), 'explain() added in Django 2.1')
+    def test_not_supported(self):
+        """Older versions of Django raise an attribute error."""
+        with self.assertRaises(AttributeError):
+            self.all.explain()
+
+    @skipIf(django.VERSION < (2, 1), 'explain() added in Django 2.1')
+    def test_supported(self):
+        """Supported versions of Django support explain() and return a string."""
+        with self.assertNumQueries(2):
+            explaination = self.all.explain()
+        self.assertEqual(explaination, '2 0 0 SCAN TABLE tests_book\n2 0 0 SCAN TABLE tests_article')
+
+
 class TestCannotImplement(TestCase):
     """The following methods cannot be implemented in QuerySetSequence."""
     def setUp(self):
@@ -1474,7 +1490,3 @@ class TestNotImplemented(TestCase):
     def test_aggregate(self):
         with self.assertRaises(NotImplementedError):
             self.all.aggregate()
-
-    def test_explain(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.explain()

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1404,8 +1404,9 @@ class TestExplain(TestBase):
     def test_supported(self):
         """Supported versions of Django support explain() and return a string."""
         with self.assertNumQueries(2):
-            explaination = self.all.explain()
-        self.assertEqual(explaination, '2 0 0 SCAN TABLE tests_book\n2 0 0 SCAN TABLE tests_article')
+            explanation = self.all.explain()
+        # The output of explain is not guaranteed, so do some rough checks.
+        self.assertEqual(len(explanation.split('\n')), 2)
 
 
 class TestCannotImplement(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
     # Django 2.0 drops support for Python 2.7.
     py{34,36}-django20,
     # Django 2.1 drops support for Python 3.4.
-    py36-djangomaster,
+    py36-django{21,master},
     # Django REST Framework 3.4 added support for Django 1.10.
     # Django REST Framework 3.7 added support for Django 2.0, dropped support for Django 1.8 and 1.9.
     py{27,34,36}-django111-drf{34,35,36,37,master},


### PR DESCRIPTION
Add support for `explain()`, which just concatenates the strings of each `QuerySet`.