### PR TITLE
Add get_queryset method to expose QuerySet objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 next (2018-xx-xx)
 =================
 
+* [Enhancement] Add a ``QuerySetSequence`` specific method: ``get_querysets()``.
 * [Enhancement] Officially support Django 2.2.
 * [Enhancement] Officially support Django REST Framework 3.9.
 * [Enhancement] Officially support Python 3.7.

--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,20 @@ multiple ``QuerySets``:
       - |check|
       - Only available on Django >= 2.1.
 
+.. list-table:: Additional methods specific to ``QuerySetSequence``
+    :widths: 15 30
+    :header-rows: 1
+
+    * - Method
+      - Notes
+
+    * - |get_querysets|
+      - Returns the list of ``QuerySet`` objects that comprise the sequence.
+        Note, if any methods have been called which modify the
+        ``QuerySetSequence``, the ``QuerySet`` objects returned by this
+        method will be similarly modified. The order of the ``QuerySet``
+        objects within the list is not guaranteed.
+
 .. |filter| replace:: ``filter()``
 .. _filter: https://docs.djangoproject.com/en/dev/ref/models/querysets/#filter
 .. |exclude| replace:: ``exclude()``
@@ -293,6 +307,8 @@ multiple ``QuerySets``:
 .. _as_manager: https://docs.djangoproject.com/en/dev/ref/models/querysets/#as-manager
 .. |explain| replace:: ``explain()``
 .. _explain: https://docs.djangoproject.com/en/dev/ref/models/querysets/#explain
+
+.. |get_querysets| replace:: ``get_querysets()``
 
 .. [1]  ``QuerySetSequence`` supports a special field lookup that looks up the
         index of the ``QuerySet``, this is represented by ``'#'``. This can be

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -659,6 +659,10 @@ class QuerySetSequence(ComparatorMixin):
         # Return the only result found.
         return result
 
+    def get_querysets(self):
+        """ Returns the QuerySet objects which form the sequence"""
+        return self._querysets
+
     def create(self, **kwargs):
         raise NotImplementedError()
 

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -659,10 +659,6 @@ class QuerySetSequence(ComparatorMixin):
         # Return the only result found.
         return result
 
-    def get_querysets(self):
-        """ Returns the QuerySet objects which form the sequence"""
-        return self._querysets
-
     def create(self, **kwargs):
         raise NotImplementedError()
 
@@ -821,3 +817,8 @@ class QuerySetSequence(ComparatorMixin):
         clause.
         """
         return bool(self._order_by)
+
+    # Methods specific to QuerySetSequence.
+    def get_querysets(self):
+        """Returns a list of the QuerySet objects which form the sequence."""
+        return self._querysets

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1249,17 +1249,6 @@ class TestGet(TestBase):
             self.empty.get(pk=1)
 
 
-class TestGetQueryset(TestBase):
-    """Tests related to retrieving QuerySets from the Squence"""
-    def test_get_querysets(self):
-        """Ensure the correct QuerySet objects are returned."""
-        querysets = [Book.objects.all(), Article.objects.all()]
-        matched_qss = QuerySetSequence(*querysets)
-        unmatched_qss = QuerySetSequence(self.big_books)
-        self.assertEqual(set(querysets), set(matched_qss.get_querysets()))
-        self.assertNotEqual({self.wacky_website}, set(unmatched_qss.get_querysets()))
-
-
 class TestBoolean(TestBase):
     """Tests related to casting the QuerySetSequence to a boolean."""
     def test_exists(self):
@@ -1480,6 +1469,16 @@ class TestExplain(TestBase):
             explanation = self.all.explain()
         # The output of explain is not guaranteed, so do some rough checks.
         self.assertEqual(len(explanation.split('\n')), 2)
+
+
+class TestGetQueryset(TestBase):
+    """Tests related to retrieving QuerySets from the sequence."""
+    def test_get_querysets(self):
+        """Ensure the correct QuerySet objects are returned."""
+        querysets = [Book.objects.all(), Article.objects.all()]
+        matched_qss = QuerySetSequence(*querysets)
+
+        self.assertEqual(querysets, matched_qss.get_querysets())
 
 
 class TestCannotImplement(TestCase):

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1249,6 +1249,17 @@ class TestGet(TestBase):
             self.empty.get(pk=1)
 
 
+class TestGetQueryset(TestBase):
+    """Tests related to retrieving QuerySets from the Squence"""
+    def test_get_querysets(self):
+        """Ensure the correct QuerySet objects are returned."""
+        querysets = [Book.objects.all(), Article.objects.all()]
+        matched_qss = QuerySetSequence(*querysets)
+        unmatched_qss = QuerySetSequence(self.big_books)
+        self.assertEqual(set(querysets), set(matched_qss.get_querysets()))
+        self.assertNotEqual({self.wacky_website}, set(unmatched_qss.get_querysets()))
+
+
 class TestBoolean(TestBase):
     """Tests related to casting the QuerySetSequence to a boolean."""
     def test_exists(self):


### PR DESCRIPTION
Downstream projects desire the ability to retrieve the individual
`QuerySet` objects which form the `QuerySetSequence`.  This commit adds
a new `get_querysets` method as part of a stable public API to return
the list of `QuerySet` objects that the sequence object is currently
wrapping.

Tests and documentation updates are present, noting some of the caveats
around this method. Notably, the component querysets will differ from
those used to construct the original `QuerySetSequence` object if
methods have been invoked which modify the sequence. Also that the
order in which the `QuerySet` objects are returned is not guaranteed
to be constant.

Fixes #21