### PR TITLE
Test Django 2.2 without DRF.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist =
     # Without Django REST Framework.
     py{27,36}-django111,
     # Django 2.0 drops support for Python 2.7.
-    py{36,37}-django{20,21,master},
+    py{36,37}-django{20,21,22,master},
     # Django REST Framework 3.6.3 added support for Django 1.11.
     py{27,36,37}-django111-drf{36,37,38,39,master},
     # Django REST Framework 3.7 added support for Django 2.0.


### PR DESCRIPTION
Realized that #51 missed using Django 2.2 without Django REST Framework.