### PR TITLE
Update README for 1.8 < 1.11 Django users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -360,6 +360,8 @@ Requirements
 
 .. _Django REST Framework: http://www.django-rest-framework.org/
 
+* Version 0.8 lower supports Django 1.11 >= 1.8 
+
 Installation
 ============
 


### PR DESCRIPTION
Some people like me are still with legacy versions, your library is pretty cool and specially useful for us that we cannot enjoy still .union() method for querysets, this will help people to identify which version they should use in this case.

I came here from this article https://strongarm.io/blog/combining-disparate-querysets-in-django/ and there they say you support
Django  1.8