### PR TITLE
Update supported versions for Django and DRF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: xenial
 language: python
 python:
+  - 3.8
   - 3.7
   - 3.6
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,10 @@ language: python
 python:
   - 3.7
   - 3.6
-  - 2.7
 env:
   - TOX_SKIP_ENV=".*djangomaster.*"
   - TOX_SKIP_ENV=".*django[^m].*"
 matrix:
-  exclude:
-    - python: 2.7
-      env: TOX_SKIP_ENV=".*django[^m].*"
   allow_failures:
     - env: TOX_SKIP_ENV=".*django[^m].*"
 script: tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ Changelog
 next (xxx)
 ==========
 
-* [Incompatible change] Drop support for Python 2.7, Django 2.0.
+* [Incompatible change] Drop support for Python 2.7.
+* [Incompatible change] Drop support for Django 2.0 and 2.1.
 
 0.11 (2019-04-25)
 =================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 next (xxx)
 ==========
 
-* [Incompatible change] Drop support for Django 2.0.
+* [Incompatible change] Drop support for Python 2.7, Django 2.0.
 
 0.11 (2019-04-25)
 =================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ next (xxx)
 
 * [Incompatible change] Drop support for Python 2.7.
 * [Incompatible change] Drop support for Django 2.0 and 2.1.
+* [Enhancement] Officially support Django 3.0.
+* [Enhancement] Officially support Python 3.8.
 
 0.11 (2019-04-25)
 =================

--- a/README.rst
+++ b/README.rst
@@ -355,7 +355,7 @@ Requirements
 ============
 
 * Python (3.5, 3.6, 3.7)
-* Django (1.11, 2.1, 2.2)
+* Django (1.11, 2.2)
 * (Optionally) `Django REST Framework`_ (3.6.3+, 3.7, 3.8, 3.9, 3.10)
 
 .. _Django REST Framework: http://www.django-rest-framework.org/

--- a/README.rst
+++ b/README.rst
@@ -354,8 +354,8 @@ multiple ``QuerySets``:
 Requirements
 ============
 
-* Python (3.5, 3.6, 3.7)
-* Django (1.11, 2.2)
+* Python (3.5, 3.6, 3.7, 3.8)
+* Django (1.11, 2.2, 3.0)
 * (Optionally) `Django REST Framework`_ (3.6.3+, 3.7, 3.8, 3.9, 3.10)
 
 .. _Django REST Framework: http://www.django-rest-framework.org/

--- a/README.rst
+++ b/README.rst
@@ -354,9 +354,9 @@ multiple ``QuerySets``:
 Requirements
 ============
 
-* Python (2.7, 3.5, 3.6, 3.7)
+* Python (3.5, 3.6, 3.7)
 * Django (1.11, 2.1, 2.2)
-* (Optionally) `Django REST Framework`_ (3.6.3+, 3.7, 3.8, 3.9)
+* (Optionally) `Django REST Framework`_ (3.6.3+, 3.7, 3.8, 3.9, 3.10)
 
 .. _Django REST Framework: http://www.django-rest-framework.org/
 

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -12,7 +12,6 @@ from django.db import transaction
 from django.db.models.base import Model
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query import EmptyQuerySet, QuerySet
-from django.utils import six
 
 # Only export the public API for QuerySetSequence. (Note that QuerySequence and
 # QuerySetSequenceModel are considered semi-public: the APIs probably won't
@@ -355,7 +354,7 @@ class QuerySetSequence(ComparatorMixin):
         """
         Retrieves an item or slice from the set of results.
         """
-        if not isinstance(k, (slice,) + six.integer_types):
+        if not isinstance(k, (int, slice)):
             raise TypeError
         assert ((not isinstance(k, slice) and (k >= 0)) or
                 (isinstance(k, slice) and (k.start is None or k.start >= 0) and
@@ -495,19 +494,19 @@ class QuerySetSequence(ComparatorMixin):
 
             # Some of these seem to get handled as bytes.
             if lookup in ('contains', 'icontains'):
-                value = six.text_type(value)
-                self._queryset_idxs = filter(lambda i: (value in six.text_type(i)) != negate, self._queryset_idxs)
+                value = str(value)
+                self._queryset_idxs = filter(lambda i: (value in str(i)) != negate, self._queryset_idxs)
 
             elif lookup == 'in':
                 self._queryset_idxs = filter(lambda i: (i in value) != negate, self._queryset_idxs)
 
             elif lookup in ('startswith', 'istartswith'):
-                value = six.text_type(value)
-                self._queryset_idxs = filter(lambda i: six.text_type(i).startswith(value) != negate, self._queryset_idxs)
+                value = str(value)
+                self._queryset_idxs = filter(lambda i: str(i).startswith(value) != negate, self._queryset_idxs)
 
             elif lookup in ('endswith', 'iendswith'):
-                value = six.text_type(value)
-                self._queryset_idxs = filter(lambda i: six.text_type(i).endswith(value) != negate, self._queryset_idxs)
+                value = str(value)
+                self._queryset_idxs = filter(lambda i: str(i).endswith(value) != negate, self._queryset_idxs)
 
             elif lookup == 'range':
                 # Inclusive include.

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -21,7 +21,7 @@ __all__ = ['QuerySetSequence']
 
 
 def cmp(a, b):
-    """Python 2 & 3 version of cmp built-in."""
+    """Python 3 version of cmp built-in."""
     return (a > b) - (a < b)
 
 
@@ -346,9 +346,6 @@ class QuerySetSequence(ComparatorMixin):
     def __bool__(self):
         self._fetch_all()
         return bool(self._result_cache)
-
-    def __nonzero__(self):      # Python 2 compatibility
-        return type(self).__bool__(self)
 
     def __getitem__(self, k):
         """

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -41,7 +41,7 @@ def cumsum(seq):
         yield s
 
 
-class ComparatorMixin(object):
+class ComparatorMixin:
     @classmethod
     def _get_field_names(cls, model):
         """Return a list of field names that are part of a model."""

--- a/queryset_sequence/pagination.py
+++ b/queryset_sequence/pagination.py
@@ -9,8 +9,7 @@ particular fields.
 
 """
 from base64 import b64decode
-
-from django.utils.six.moves.urllib import parse as urlparse
+from urllib import parse
 
 from queryset_sequence import QuerySetSequence
 
@@ -195,7 +194,7 @@ class SequenceCursorPagination(CursorPagination):
 
         try:
             querystring = b64decode(encoded.encode('ascii')).decode('ascii')
-            tokens = urlparse.parse_qs(querystring, keep_blank_values=True)
+            tokens = parse.parse_qs(querystring, keep_blank_values=True)
 
             offset = tokens.get('o', ['0'])[0]
             offset = _positive_int(offset, cutoff=self.offset_cutoff)

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from datetime import date
 from unittest import skip, skipIf
+from unittest.mock import patch
 
 import django
 from django.core.exceptions import (FieldDoesNotExist,
@@ -11,11 +12,6 @@ from django.core.exceptions import (FieldDoesNotExist,
 from django.db.models import Count
 from django.db.models.query import EmptyQuerySet
 from django.test import TestCase
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
 
 from queryset_sequence import QuerySetSequence
 

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -805,7 +805,7 @@ class TestExtraAnnotate(TestBase):
         # Each Published gets the count of things in it added.
         with self.assertNumQueries(2):
             data = [it.published_count for it in qss]
-        self.assertEquals(data, [0, 2, 3])
+        self.assertEqual(data, [0, 2, 3])
 
 
 class TestOrderBy(TestBase):

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,11 @@
 # versions.
 envlist =
     # Without Django REST Framework.
-    py{36}-django{111,22,30,master},
+    py{36,37,38}-django{111,22,30,master},
     # Django REST Framework 3.6.3 added support for Django 1.11.
-    py{36,37}-django111-drf{36,37,38,39,310,master},
+    py{36,37,38}-django111-drf{36,37,38,39,310,master},
     # Django REST Framework 3.9.2 added support for Django 2.2.
-    py{36,37}-django{22,30,master}-drf{39,310,master}
+    py{36,37,38}-django{22,30,master}-drf{39,310,master}
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,9 @@
 # versions.
 envlist =
     # Without Django REST Framework.
-    py{27,36}-django111,
-    # Django 2.0 drops support for Python 2.7.
-    py{36,37}-django{21,22,master},
+    py{36}-django{111,22,master},
     # Django REST Framework 3.6.3 added support for Django 1.11.
-    py{27,36,37}-django111-drf{36,37,38,39},
-    # Django REST Framework 3.10 dropped support for Python 2.7.
-    py{36,37}-django111-drf{10,master},
+    py{36,37}-django111-drf{36,37,38,39,30,master},
     # Django REST Framework 3.9 added support for Django 2.1 and 3.9.2 for Django 2.2.
     py{36,37}-django{21,22,master}-drf{39,310,master}
 skip_missing_interpreters = True
@@ -28,7 +24,6 @@ commands =
     coverage html
 deps =
     coverage
-    py27: mock
     django111: Django>=1.11,<2.0
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,11 @@
 # versions.
 envlist =
     # Without Django REST Framework.
-    py{36}-django{111,22,master},
+    py{36}-django{111,22,30,master},
     # Django REST Framework 3.6.3 added support for Django 1.11.
-    py{36,37}-django111-drf{36,37,38,39,30,master},
-    # Django REST Framework 3.9 added support for Django 2.1 and 3.9.2 for Django 2.2.
-    py{36,37}-django{21,22,master}-drf{39,310,master}
+    py{36,37}-django111-drf{36,37,38,39,310,master},
+    # Django REST Framework 3.9.2 added support for Django 2.2.
+    py{36,37}-django{22,30,master}-drf{39,310,master}
 skip_missing_interpreters = True
 
 [testenv]
@@ -25,13 +25,12 @@ commands =
 deps =
     coverage
     django111: Django>=1.11,<2.0
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     djangomaster: https://codeload.github.com/django/django/zip/master
     drf36: djangorestframework>=3.6.3,<3.7
     drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8,<3.9
-    drf39: djangorestframework>=3.9,<3.10
+    drf39: djangorestframework>=3.9.2,<3.10
     drf310: djangorestframework>=3.10,<3.11
     drfmaster: https://codeload.github.com/tomchristie/django-rest-framework/zip/master

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ envlist =
     # Django REST Framework 3.6.3 added support for Django 1.11.
     py{27,36,37}-django111-drf{36,37,38,39},
     # Django REST Framework 3.10 dropped support for Python 2.7.
-    py{36,37}-django111-drfmaster,
+    py{36,37}-django111-drf{10,master},
     # Django REST Framework 3.9 added support for Django 2.1 and 3.9.2 for Django 2.2.
-    py{36,37}-django{21,22,master}-drf{39,master}
+    py{36,37}-django{21,22,master}-drf{39,310,master}
 skip_missing_interpreters = True
 
 [testenv]
@@ -31,10 +31,12 @@ deps =
     py27: mock
     django111: Django>=1.11,<2.0
     django21: Django>=2.1,<2.2
-    django22: Django>=2.2b1,<3.0
+    django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
     djangomaster: https://codeload.github.com/django/django/zip/master
     drf36: djangorestframework>=3.6.3,<3.7
     drf37: djangorestframework>=3.7,<3.8
     drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9,<3.10
+    drf310: djangorestframework>=3.10,<3.11
     drfmaster: https://codeload.github.com/tomchristie/django-rest-framework/zip/master


### PR DESCRIPTION
This drops support for Python 2.7, adds support for Python 3.8.

This drops support for Django 2.0, Django 2.1 (both now unsupported), adds support for Django 3.0.

Fixes #58