### PR TITLE
Fixes syntax warning about comparing to an integer using "is"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ next (xxx)
 * [Incompatible change] Drop support for Django 2.0 and 2.1.
 * [Enhancement] Officially support Django 3.0.
 * [Enhancement] Officially support Python 3.8.
+* [Bugfix] Do not use ``is not`` to compare to an integer literal.
 
 0.11 (2019-04-25)
 =================

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -250,7 +250,7 @@ class QuerySequenceIterable(ComparatorMixin):
         # Trim the beginning of the QuerySets, if necessary.
         start_index = 0
         low_mark, high_mark = self._low_mark, self._high_mark
-        if low_mark is not 0:
+        if low_mark != 0:
             # Convert a negative index into a positive.
             if low_mark < 0:
                 low_mark += counts[-1]


### PR DESCRIPTION
Fixes #60. I tested quickly in pypy3 and this didn't seem to actually cause a bug, but still good to fix it.