### PR TITLE
Add information about the bulk_update() method.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,9 @@ multiple ``QuerySets``:
     * - |bulk_create|_
       - |xmark|
       - Cannot be implemented in ``QuerySetSequence``.
+    * - |bulk_update|_
+      - |xmark|
+      - Cannot be implemented in ``QuerySetSequence``.
     * - |count|_
       - |check|
       -
@@ -281,6 +284,8 @@ multiple ``QuerySets``:
 .. _update_or_create: https://docs.djangoproject.com/en/dev/ref/models/querysets/#update-or-create
 .. |bulk_create| replace:: ``bulk_create()``
 .. _bulk_create: https://docs.djangoproject.com/en/dev/ref/models/querysets/#bulk-create
+.. |bulk_update| replace:: ``bulk_update()``
+.. _bulk_update: https://docs.djangoproject.com/en/dev/ref/models/querysets/#bulk-update
 .. |count| replace:: ``count()``
 .. _count: https://docs.djangoproject.com/en/dev/ref/models/querysets/#count
 .. |in_bulk| replace:: ``in_bulk()``

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -667,6 +667,10 @@ class QuerySetSequence(ComparatorMixin):
     def bulk_create(self, objs, batch_size=None, ignore_conflicts=False):
         raise NotImplementedError()
 
+    if django.VERSION >= (2, 2):
+        def bulk_update(self, objs, fields, batch_size=None):
+            raise NotImplementedError()
+
     def count(self):
         return sum(qs.count() for qs in self._querysets) - self._low_mark
 

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1498,6 +1498,16 @@ class TestCannotImplement(TestCase):
         with self.assertRaises(NotImplementedError):
             self.all.bulk_create([])
 
+    @skipIf(django.VERSION >= (2, 2), 'bulk_update() added in Django 2.2')
+    def test_bulk_update_not_supported(self):
+        with self.assertRaises(AttributeError):
+            self.all.bulk_update([], [])
+
+    @skipIf(django.VERSION < (2, 2), 'bulk_update() added in Django 2.2')
+    def test_bulk_update(self):
+        with self.assertRaises(NotImplementedError):
+            self.all.bulk_update([], [])
+
     def test_in_bulk(self):
         with self.assertRaises(NotImplementedError):
             self.all.in_bulk()


### PR DESCRIPTION
Django 2.2 added a new `QuerySet` method. It isn't supported, but we should include it.