### PR TITLE
Add Django REST Framework 3.11 to the build matrix.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changelog
 * [Incompatible change] Drop support for Django 2.0 and 2.1.
 * [Enhancement] Officially support Django 3.0.
 * [Enhancement] Officially support Python 3.8.
+* [Enhancement] Officially support Django REST Framework 3.10 and 3.11.
 * [Bugfix] Do not use ``is not`` to compare to an integer literal.
 
 0.11 (2019-04-25)

--- a/README.rst
+++ b/README.rst
@@ -361,7 +361,7 @@ Requirements
 
 * Python (3.5, 3.6, 3.7, 3.8)
 * Django (1.11, 2.2, 3.0)
-* (Optionally) `Django REST Framework`_ (3.6.3+, 3.7, 3.8, 3.9, 3.10)
+* (Optionally) `Django REST Framework`_ (3.6.3+, 3.7, 3.8, 3.9, 3.10, 3.11)
 
 .. _Django REST Framework: http://www.django-rest-framework.org/
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,11 @@ envlist =
     # Without Django REST Framework.
     py{36,37,38}-django{111,22,30,master},
     # Django REST Framework 3.6.3 added support for Django 1.11.
-    py{36,37,38}-django111-drf{36,37,38,39,310,master},
+    py{36,37,38}-django111-drf{36,37,38,39,310,311,master},
     # Django REST Framework 3.9.2 added support for Django 2.2.
-    py{36,37,38}-django{22,30,master}-drf{39,310,master}
+    py{36,37,38}-django22-drf{39,310,311,master},
+    # Django REST Framework 3.11 added support for Django 3.0.
+    py{36,37,38}-django{30,master}-drf{311,master}
 skip_missing_interpreters = True
 
 [testenv]
@@ -33,4 +35,5 @@ deps =
     drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9.2,<3.10
     drf310: djangorestframework>=3.10,<3.11
+    drf311: djangorestframework>=3.11,<3.12
     drfmaster: https://codeload.github.com/tomchristie/django-rest-framework/zip/master


### PR DESCRIPTION
This adds Django REST Framework 3.11 to the build matrix and updates the CHANGELOG.