### PR TITLE
Drop support for Django 1.11.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ next (xxx)
 ==========
 
 * [Enhancement] Officially support Django 3.1.
+* [Incompatible change] Drop support for Django < 2.2.
 * [Bugfix] ``explain()`` now passes through parameters to the underlying
   ``QuerySet`` instances.
 

--- a/README.rst
+++ b/README.rst
@@ -360,8 +360,8 @@ Requirements
 ============
 
 * Python (3.5, 3.6, 3.7, 3.8)
-* Django (1.11, 2.2, 3.0)
-* (Optionally) `Django REST Framework`_ (3.6.3+, 3.7, 3.8, 3.9, 3.10, 3.11)
+* Django (2.2, 3.0, 3.1)
+* (Optionally) `Django REST Framework`_ (3.9, 3.10, 3.11)
 
 .. _Django REST Framework: http://www.django-rest-framework.org/
 

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -670,9 +670,8 @@ class QuerySetSequence(ComparatorMixin):
     def bulk_create(self, objs, batch_size=None, ignore_conflicts=False):
         raise NotImplementedError()
 
-    if django.VERSION >= (2, 2):
-        def bulk_update(self, objs, fields, batch_size=None):
-            raise NotImplementedError()
+    def bulk_update(self, objs, fields, batch_size=None):
+        raise NotImplementedError()
 
     def count(self):
         return sum(qs.count() for qs in self._querysets) - self._low_mark
@@ -808,9 +807,8 @@ class QuerySetSequence(ComparatorMixin):
     def as_manager(self):
         raise NotImplementedError()
 
-    if django.VERSION >= (2, 1):
-        def explain(self, format=None, **options):
-            return '\n'.join(qs.explain(format=format, **options) for qs in self._querysets)
+    def explain(self, format=None, **options):
+        return '\n'.join(qs.explain(format=format, **options) for qs in self._querysets)
 
     # Public attributes
     @property

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1285,14 +1285,12 @@ class TestEarliestLatest(TestBase):
             latest = self.all.latest('release')
         self.assertEqual(latest.title, 'Biography')
 
-    @skipIf(django.VERSION < (2, 0), 'Support for reversed calls to earliest() and latest() was added in Django 2.0')
     def test_earliest_reverse(self):
         """The earliest release overall reversed is the latest."""
         with self.assertNumQueries(2):
             earliest = self.all.earliest('-release')
         self.assertEqual(earliest.title, 'Biography')
 
-    @skipIf(django.VERSION < (2, 0), 'Support for reversed calls to earliest() and latest() was added in Django 2.0')
     def test_latest_reverse(self):
         """The latest release overall reversed is the earliest."""
         with self.assertNumQueries(2):
@@ -1456,13 +1454,6 @@ class TestDelete(TestBase):
 
 
 class TestExplain(TestBase):
-    @skipIf(django.VERSION >= (2, 1), 'explain() added in Django 2.1')
-    def test_not_supported(self):
-        """Older versions of Django raise an attribute error."""
-        with self.assertRaises(AttributeError):
-            self.all.explain()
-
-    @skipIf(django.VERSION < (2, 1), 'explain() added in Django 2.1')
     def test_supported(self):
         """Supported versions of Django support explain() and return a string."""
         with self.assertNumQueries(2):
@@ -1502,12 +1493,6 @@ class TestCannotImplement(TestCase):
         with self.assertRaises(NotImplementedError):
             self.all.bulk_create([])
 
-    @skipIf(django.VERSION >= (2, 2), 'bulk_update() added in Django 2.2')
-    def test_bulk_update_not_supported(self):
-        with self.assertRaises(AttributeError):
-            self.all.bulk_update([], [])
-
-    @skipIf(django.VERSION < (2, 2), 'bulk_update() added in Django 2.2')
     def test_bulk_update(self):
         with self.assertRaises(NotImplementedError):
             self.all.bulk_update([], [])

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,7 @@
 # versions.
 envlist =
     # Without Django REST Framework.
-    py{36,37,38}-django{111,22,30,master},
-    # Django REST Framework 3.6.3 added support for Django 1.11.
-    py{36,37,38}-django111-drf{36,37,38,39,310,311,master},
+    py{36,37,38}-django{22,30,31,master},
     # Django REST Framework 3.9.2 added support for Django 2.2.
     py{36,37,38}-django22-drf{39,310,311,master},
     # Django REST Framework 3.11 added support for Django 3.0.
@@ -26,14 +24,10 @@ commands =
     coverage html
 deps =
     coverage
-    django111: Django>=1.11,<2.0
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     django31: Django>=3.1b1,<3.2
     djangomaster: https://codeload.github.com/django/django/zip/master
-    drf36: djangorestframework>=3.6.3,<3.7
-    drf37: djangorestframework>=3.7,<3.8
-    drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9.2,<3.10
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12


### PR DESCRIPTION
This drops support for old Django and Django REST Framework versions.